### PR TITLE
Add impulse response transformation

### DIFF
--- a/tests/test_impulse_response.py
+++ b/tests/test_impulse_response.py
@@ -9,6 +9,7 @@ class TestApplyImpulseResponse(unittest.TestCase):
     def setUp(self):
         self.sample_rate = 16000
         self.batch_size = 32
+        self.empty_input_audio = torch.empty(0)
         self.input_audio = torch.from_numpy(load_audio(os.path.join(TEST_FIXTURES_DIR, "acoustic_guitar_0.wav"), self.sample_rate))
         self.input_audios = torch.stack([self.input_audio] * self.batch_size)
         self.ir_path = os.path.join(TEST_FIXTURES_DIR, "ir")
@@ -32,3 +33,7 @@ class TestApplyImpulseResponse(unittest.TestCase):
         mixed_inputs = self.ir_transform_no_guarantee(self.input_audios, self.sample_rate)
         self.assertEqual(mixed_inputs.size(0), self.input_audios.size(0))
         self.assertEqual(mixed_inputs.size(-1), self.input_audios.size(-1))
+
+    def test_impulse_response_guaranteed_with_zero_length_samples(self):
+        mixed_inputs = self.ir_transform_guaranteed(self.empty_input_audio, self.sample_rate)
+        self.assertTrue(torch.equal(mixed_inputs, self.empty_input_audio))

--- a/tests/test_impulse_response.py
+++ b/tests/test_impulse_response.py
@@ -12,13 +12,23 @@ class TestApplyImpulseResponse(unittest.TestCase):
         self.input_audio = torch.from_numpy(load_audio(os.path.join(TEST_FIXTURES_DIR, "acoustic_guitar_0.wav"), self.sample_rate))
         self.input_audios = torch.stack([self.input_audio] * self.batch_size)
         self.ir_path = os.path.join(TEST_FIXTURES_DIR, "ir")
-        self.ir_transform = ApplyImpulseResponse(self.ir_path, p=1.0)
+        self.ir_transform_guaranteed = ApplyImpulseResponse(self.ir_path, p=1.0)
+        self.ir_transform_no_guarantee = ApplyImpulseResponse(self.ir_path, p=0.0)
 
-    def test_impulse_response_with_single_tensor_input(self):
-        mixed_input = self.ir_transform(self.input_audio, self.sample_rate)
+    def test_impulse_response_guaranteed_with_single_tensor_input(self):
+        mixed_input = self.ir_transform_guaranteed(self.input_audio, self.sample_rate)
         self.assertNotEqual(mixed_input.size(-1), self.input_audio.size(-1))
 
-    def test_impulse_response_with_batched_tensor_input(self):
-        mixed_inputs = self.ir_transform(self.input_audios, self.sample_rate)
+    def test_impulse_response_guaranteed_with_batched_tensor_input(self):
+        mixed_inputs = self.ir_transform_guaranteed(self.input_audios, self.sample_rate)
         self.assertEqual(mixed_inputs.size(0), self.input_audios.size(0))
         self.assertNotEqual(mixed_inputs.size(-1), self.input_audios.size(-1))
+
+    def test_impulse_response_no_guarantee_with_single_tensor_input(self):
+        mixed_input = self.ir_transform_no_guarantee(self.input_audio, self.sample_rate)
+        self.assertEqual(mixed_input.size(-1), self.input_audio.size(-1))
+
+    def test_impulse_response_no_guarantee_with_batched_tensor_input(self):
+        mixed_inputs = self.ir_transform_no_guarantee(self.input_audios, self.sample_rate)
+        self.assertEqual(mixed_inputs.size(0), self.input_audios.size(0))
+        self.assertEqual(mixed_inputs.size(-1), self.input_audios.size(-1))

--- a/tests/test_impulse_response.py
+++ b/tests/test_impulse_response.py
@@ -1,0 +1,41 @@
+import numpy as np
+import os
+import torch
+import unittest
+from numpy.testing import assert_almost_equal
+from torch_audiomentations import load_audio
+from torch_audiomentations import ImpulseResponse
+from pathlib import Path
+
+
+BASE_DIR = Path(os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+TEST_FIXTURES_DIR = BASE_DIR / "test_fixtures"
+
+
+class TestImpulseResponse(unittest.TestCase):
+    def setUp(self):
+        self.sample_rate = 48000
+        self.batch_size = 32
+        self.input_audio = load_audio(os.path.join(TEST_FIXTURES_DIR, 'acoustic_guitar_0.wav'), self.sample_rate)
+        self.input_audios = np.stack([self.input_audio] * self.batch_size)
+        self.ir_path = os.path.join(TEST_FIXTURES_DIR, 'ir')
+        self.ir_transform = ImpulseResponse(self.ir_path, p=1.0)
+
+    def test_impulse_response_with_single_ndarray_input(self):
+        mixed_input = self.ir_transform(self.input_audio, self.sample_rate)
+        self.assertNotEqual(mixed_input.shape[-1], self.input_audio.shape[-1])
+
+    def test_impulse_response_with_batched_ndarray_input(self):
+        mixed_inputs = self.ir_transform(self.input_audios, self.sample_rate)
+        self.assertEqual(mixed_inputs.shape[0], self.input_audios.shape[0])
+        self.assertNotEqual(mixed_inputs.shape[-1], self.input_audios.shape[-1])
+
+    def test_impulse_response_with_single_tensor_input(self):
+        mixed_input = self.ir_transform(torch.from_numpy(self.input_audio), self.sample_rate)
+        self.assertNotEqual(mixed_input.shape[-1], self.input_audio.shape[-1])
+
+    def test_impulse_response_with_batched_tensor_input(self):
+        mixed_inputs = self.ir_transform(torch.from_numpy(self.input_audios), self.sample_rate)
+        self.assertEqual(mixed_inputs.shape[0], self.input_audios.shape[0])
+        self.assertNotEqual(mixed_inputs.shape[-1], self.input_audios.shape[-1])
+

--- a/tests/test_impulse_response.py
+++ b/tests/test_impulse_response.py
@@ -1,10 +1,8 @@
-import numpy as np
 import os
 import torch
 import unittest
-from numpy.testing import assert_almost_equal
 from torch_audiomentations import load_audio
-from torch_audiomentations import ImpulseResponse
+from torch_audiomentations import ApplyImpulseResponse
 from pathlib import Path
 
 
@@ -12,30 +10,21 @@ BASE_DIR = Path(os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 TEST_FIXTURES_DIR = BASE_DIR / "test_fixtures"
 
 
-class TestImpulseResponse(unittest.TestCase):
+class TestApplyImpulseResponse(unittest.TestCase):
     def setUp(self):
         self.sample_rate = 48000
         self.batch_size = 32
-        self.input_audio = load_audio(os.path.join(TEST_FIXTURES_DIR, 'acoustic_guitar_0.wav'), self.sample_rate)
-        self.input_audios = np.stack([self.input_audio] * self.batch_size)
+        self.input_audio = torch.from_numpy(load_audio(os.path.join(TEST_FIXTURES_DIR, 'acoustic_guitar_0.wav'), self.sample_rate))
+        self.input_audios = torch.stack([self.input_audio] * self.batch_size)
         self.ir_path = os.path.join(TEST_FIXTURES_DIR, 'ir')
-        self.ir_transform = ImpulseResponse(self.ir_path, p=1.0)
+        self.ir_transform = ApplyImpulseResponse(self.ir_path, p=1.0)
 
-    def test_impulse_response_with_single_ndarray_input(self):
+    def test_impulse_response_with_single_tensor_input(self):
         mixed_input = self.ir_transform(self.input_audio, self.sample_rate)
         self.assertNotEqual(mixed_input.shape[-1], self.input_audio.shape[-1])
 
-    def test_impulse_response_with_batched_ndarray_input(self):
-        mixed_inputs = self.ir_transform(self.input_audios, self.sample_rate)
-        self.assertEqual(mixed_inputs.shape[0], self.input_audios.shape[0])
-        self.assertNotEqual(mixed_inputs.shape[-1], self.input_audios.shape[-1])
-
-    def test_impulse_response_with_single_tensor_input(self):
-        mixed_input = self.ir_transform(torch.from_numpy(self.input_audio), self.sample_rate)
-        self.assertNotEqual(mixed_input.shape[-1], self.input_audio.shape[-1])
-
     def test_impulse_response_with_batched_tensor_input(self):
-        mixed_inputs = self.ir_transform(torch.from_numpy(self.input_audios), self.sample_rate)
+        mixed_inputs = self.ir_transform(self.input_audios, self.sample_rate)
         self.assertEqual(mixed_inputs.shape[0], self.input_audios.shape[0])
         self.assertNotEqual(mixed_inputs.shape[-1], self.input_audios.shape[-1])
 

--- a/tests/test_impulse_response.py
+++ b/tests/test_impulse_response.py
@@ -16,10 +16,9 @@ class TestApplyImpulseResponse(unittest.TestCase):
 
     def test_impulse_response_with_single_tensor_input(self):
         mixed_input = self.ir_transform(self.input_audio, self.sample_rate)
-        self.assertNotEqual(mixed_input.shape[-1], self.input_audio.shape[-1])
+        self.assertNotEqual(mixed_input.size(-1), self.input_audio.size(-1))
 
     def test_impulse_response_with_batched_tensor_input(self):
         mixed_inputs = self.ir_transform(self.input_audios, self.sample_rate)
-        self.assertEqual(mixed_inputs.shape[0], self.input_audios.shape[0])
-        self.assertNotEqual(mixed_inputs.shape[-1], self.input_audios.shape[-1])
-
+        self.assertEqual(mixed_inputs.size(0), self.input_audios.size(0))
+        self.assertNotEqual(mixed_inputs.size(-1), self.input_audios.size(-1))

--- a/tests/test_impulse_response.py
+++ b/tests/test_impulse_response.py
@@ -1,22 +1,17 @@
 import os
 import torch
 import unittest
-from torch_audiomentations import load_audio
-from torch_audiomentations import ApplyImpulseResponse
-from pathlib import Path
-
-
-BASE_DIR = Path(os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
-TEST_FIXTURES_DIR = BASE_DIR / "test_fixtures"
+from torch_audiomentations import ApplyImpulseResponse, load_audio
+from .utils import TEST_FIXTURES_DIR
 
 
 class TestApplyImpulseResponse(unittest.TestCase):
     def setUp(self):
-        self.sample_rate = 48000
+        self.sample_rate = 16000
         self.batch_size = 32
-        self.input_audio = torch.from_numpy(load_audio(os.path.join(TEST_FIXTURES_DIR, 'acoustic_guitar_0.wav'), self.sample_rate))
+        self.input_audio = torch.from_numpy(load_audio(os.path.join(TEST_FIXTURES_DIR, "acoustic_guitar_0.wav"), self.sample_rate))
         self.input_audios = torch.stack([self.input_audio] * self.batch_size)
-        self.ir_path = os.path.join(TEST_FIXTURES_DIR, 'ir')
+        self.ir_path = os.path.join(TEST_FIXTURES_DIR, "ir")
         self.ir_transform = ApplyImpulseResponse(self.ir_path, p=1.0)
 
     def test_impulse_response_with_single_tensor_input(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,4 +24,4 @@ class TestConvolution(unittest.TestCase):
             torch.from_numpy(samples), torch.from_numpy(ir_samples)
         ).numpy()
 
-        assert_almost_equal(actual_output, expected_output)
+        assert_almost_equal(actual_output, expected_output, decimal=6)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,4 +24,4 @@ class TestConvolution(unittest.TestCase):
             torch.from_numpy(samples), torch.from_numpy(ir_samples)
         ).numpy()
 
-        assert_almost_equal(expected_output, actual_output)
+        assert_almost_equal(actual_output, expected_output)

--- a/torch_audiomentations/__init__.py
+++ b/torch_audiomentations/__init__.py
@@ -1,5 +1,5 @@
 from .augmentations.polarity_inversion import PolarityInversion
-from .augmentations.impulse_response import ImpulseResponse
+from .augmentations.impulse_response import ApplyImpulseResponse
 from .utils.convolution import convolve
 from .utils.file import find_files, load_audio
 

--- a/torch_audiomentations/__init__.py
+++ b/torch_audiomentations/__init__.py
@@ -1,6 +1,6 @@
 from .augmentations.polarity_inversion import PolarityInversion
 from .augmentations.impulse_response import ApplyImpulseResponse
 from .utils.convolution import convolve
-from .utils.file import find_files, load_audio
+from .utils.file import find_audio_files, load_audio
 
 __version__ = "0.0.1"

--- a/torch_audiomentations/__init__.py
+++ b/torch_audiomentations/__init__.py
@@ -1,4 +1,6 @@
 from .augmentations.polarity_inversion import PolarityInversion
+from .augmentations.impulse_response import ImpulseResponse
 from .utils.convolution import convolve
+from .utils.file import find_files, load_audio
 
 __version__ = "0.0.1"

--- a/torch_audiomentations/augmentations/impulse_response.py
+++ b/torch_audiomentations/augmentations/impulse_response.py
@@ -23,5 +23,9 @@ class ApplyImpulseResponse(BasicTransform):
 
     def forward(self, samples, sample_rate):
         super(ApplyImpulseResponse, self).forward(samples, sample_rate)
-        ir = torch.from_numpy(load_audio(self.parameters["ir_file_path"], sample_rate))
-        return convolve(samples, ir, mode=self.convolve_mode)
+
+        if self.parameters["should_apply"] and len(samples) > 0:
+            ir = torch.from_numpy(load_audio(self.parameters["ir_file_path"], sample_rate))
+            return convolve(samples, ir, mode=self.convolve_mode)
+
+        return samples

--- a/torch_audiomentations/augmentations/impulse_response.py
+++ b/torch_audiomentations/augmentations/impulse_response.py
@@ -18,15 +18,10 @@ class ApplyImpulseResponse(BasicTransform):
 
     def randomize_parameters(self, samples, sample_rate):
         super(ApplyImpulseResponse, self).randomize_parameters(samples, sample_rate)
-
         if self.parameters["should_apply"]:
             self.parameters["ir_file_path"] = random.choice(self.ir_path)
 
-    def apply(self, samples, sample_rate):
-        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        samples = samples.to(device)
-        ir = torch.from_numpy(load_audio(self.parameters["ir_file_path"], sample_rate)).to(device)
-        signal_ir = convolve(samples, ir, mode=self.convolve_mode)
-        signal_ir = signal_ir.cpu().numpy()
-        return signal_ir
-
+    def forward(self, samples, sample_rate):
+        super(ApplyImpulseResponse, self).forward(samples, sample_rate)
+        ir = torch.from_numpy(load_audio(self.parameters["ir_file_path"], sample_rate))
+        return convolve(samples, ir, mode=self.convolve_mode)

--- a/torch_audiomentations/augmentations/impulse_response.py
+++ b/torch_audiomentations/augmentations/impulse_response.py
@@ -1,9 +1,9 @@
 import numpy as np
 import random
 import torch
-from torch_audiomentations.core.transforms_interface import BasicTransform
-from torch_audiomentations.utils.convolution import convolve
-from torch_audiomentations.utils.file import find_files, load_audio
+from ..core.transforms_interface import BasicTransform
+from ..utils.convolution import convolve
+from ..utils.file import find_audio_files, load_audio
 
 
 class ApplyImpulseResponse(BasicTransform):
@@ -13,7 +13,7 @@ class ApplyImpulseResponse(BasicTransform):
 
     def __init__(self, ir_path, convolve_mode="full", p=0.5):
         super(ApplyImpulseResponse, self).__init__(p)
-        self.ir_path = find_files(ir_path)
+        self.ir_path = find_audio_files(ir_path)
         self.convolve_mode = convolve_mode
 
     def randomize_parameters(self, samples, sample_rate):

--- a/torch_audiomentations/augmentations/impulse_response.py
+++ b/torch_audiomentations/augmentations/impulse_response.py
@@ -6,31 +6,26 @@ from torch_audiomentations.utils.convolution import convolve
 from torch_audiomentations.utils.file import find_files, load_audio
 
 
-class ImpulseResponse(BasicTransform):
+class ApplyImpulseResponse(BasicTransform):
     """
     Convolves an input signal with an impulse response.
     """
 
     def __init__(self, ir_path, convolve_mode="full", p=0.5):
-        super(ImpulseResponse, self).__init__(p)
+        super(ApplyImpulseResponse, self).__init__(p)
         self.ir_path = find_files(ir_path)
         self.convolve_mode = convolve_mode
 
     def randomize_parameters(self, samples, sample_rate):
-        super(ImpulseResponse, self).randomize_parameters(samples, sample_rate)
+        super(ApplyImpulseResponse, self).randomize_parameters(samples, sample_rate)
 
         if self.parameters["should_apply"]:
             self.parameters["ir_file_path"] = random.choice(self.ir_path)
 
     def apply(self, samples, sample_rate):
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        samples = samples.to(device)
         ir = torch.from_numpy(load_audio(self.parameters["ir_file_path"], sample_rate)).to(device)
-
-        if isinstance(samples, np.ndarray):
-            samples = torch.from_numpy(samples).to(device)
-        else:
-            samples = samples.to(device)
-
         signal_ir = convolve(samples, ir, mode=self.convolve_mode)
         signal_ir = signal_ir.cpu().numpy()
         return signal_ir

--- a/torch_audiomentations/augmentations/impulse_response.py
+++ b/torch_audiomentations/augmentations/impulse_response.py
@@ -1,0 +1,37 @@
+import numpy as np
+import random
+import torch
+from torch_audiomentations.core.transforms_interface import BasicTransform
+from torch_audiomentations.utils.convolution import convolve
+from torch_audiomentations.utils.file import find_files, load_audio
+
+
+class ImpulseResponse(BasicTransform):
+    """
+    Convolves an input signal with an impulse response.
+    """
+
+    def __init__(self, ir_path, convolve_mode="full", p=0.5):
+        super(ImpulseResponse, self).__init__(p)
+        self.ir_path = find_files(ir_path)
+        self.convolve_mode = convolve_mode
+
+    def randomize_parameters(self, samples, sample_rate):
+        super(ImpulseResponse, self).randomize_parameters(samples, sample_rate)
+
+        if self.parameters["should_apply"]:
+            self.parameters["ir_file_path"] = random.choice(self.ir_path)
+
+    def apply(self, samples, sample_rate):
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        ir = torch.from_numpy(load_audio(self.parameters["ir_file_path"], sample_rate)).to(device)
+
+        if isinstance(samples, np.ndarray):
+            samples = torch.from_numpy(samples).to(device)
+        else:
+            samples = samples.to(device)
+
+        signal_ir = convolve(samples, ir, mode=self.convolve_mode)
+        signal_ir = signal_ir.cpu().numpy()
+        return signal_ir
+

--- a/torch_audiomentations/augmentations/polarity_inversion.py
+++ b/torch_audiomentations/augmentations/polarity_inversion.py
@@ -23,5 +23,5 @@ class PolarityInversion(BasicTransform):
     def randomize_parameters(self, samples, sample_rate):
         super().randomize_parameters(samples, sample_rate)
 
-    def apply(self, samples, sample_rate):
+    def forward(self, samples, sample_rate):
         return -samples

--- a/torch_audiomentations/core/transforms_interface.py
+++ b/torch_audiomentations/core/transforms_interface.py
@@ -23,11 +23,11 @@ class BasicTransform:
             self.randomize_parameters(samples, sample_rate)
         if self.parameters["should_apply"] and len(samples) > 0:
             if is_multichannel(samples):
-                if samples.shape[0] > samples.shape[1]:
+                if samples.shape[1] > samples.shape[2]:
                     warnings.warn(
                         "Multichannel audio must have channels first, not channels last. In"
-                        " other words, the shape must be (channels, samples), not"
-                        " (samples, channels)"
+                        " other words, the shape must be (batch size, channels, samples), not"
+                        " (batch_size, samples, channels)"
                     )
                 if not self.supports_multichannel:
                     raise MultichannelAudioNotSupportedException(

--- a/torch_audiomentations/utils/file.py
+++ b/torch_audiomentations/utils/file.py
@@ -1,0 +1,21 @@
+import os
+import glob
+import librosa
+
+
+SUPPORTED_EXTENSIONS = ['.wav']
+
+
+def find_files(path):
+    """Finds all files of supported extensions."""
+    files = []
+
+    for supported_extension in SUPPORTED_EXTENSIONS:
+        files.extend(glob.glob(os.path.join(path, '*' + supported_extension)))
+
+    return files
+
+def load_audio(audio_file_path, sample_rate):
+    """Loads the audio given the path of an audio file."""
+    return librosa.load(audio_file_path, sr=sample_rate)[0]
+

--- a/torch_audiomentations/utils/file.py
+++ b/torch_audiomentations/utils/file.py
@@ -18,4 +18,3 @@ def find_audio_files(path):
 def load_audio(audio_file_path, sample_rate):
     """Loads the audio given the path of an audio file."""
     return librosa.load(audio_file_path, sr=sample_rate)[0]
-

--- a/torch_audiomentations/utils/file.py
+++ b/torch_audiomentations/utils/file.py
@@ -6,8 +6,8 @@ import librosa
 SUPPORTED_EXTENSIONS = ['.wav']
 
 
-def find_files(path):
-    """Finds all files of supported extensions."""
+def find_audio_files(path):
+    """Finds all audio files of supported extensions."""
     files = []
 
     for supported_extension in SUPPORTED_EXTENSIONS:

--- a/torch_audiomentations/utils/multichannel.py
+++ b/torch_audiomentations/utils/multichannel.py
@@ -4,4 +4,4 @@ def is_multichannel(samples):
     :param samples:
     :return:
     """
-    return len(samples.shape) > 1
+    return len(samples.shape) > 2


### PR DESCRIPTION
This pull request adds the `ImpulseResponse` transformation to the list of transformations. This uses the `torch` way of convolving input signal with IR. As a result, batch size and GPU support are added.

Note that in order to support batch size, the definition of a multi-channel has been [edited](https://github.com/asteroid-team/torch-audiomentations/compare/asteroid-team:master...francislata:feature/add-impulse-response-transform?expand=1#diff-cc224b2c34f4db0a2f2e33cc1865595cR29) so that it has the format **(batch size, number of channels, sequence length)**. This is the only modification made to the author's original implementation as to allow `ImpulseResponse` transformation to work properly.

Lastly, the tests checks to ensure that lengths of mixed and original audios do not match as the convolution itself has been tested by the original author.