### PR TITLE
[ci] Add GitHub actions to lint/test

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[report]
+fail_under=80
+# Regexes for lines to exclude from consideration
+exclude_lines =
+  pragma: no cover
+  raise NotImplementedError
+
+[run]
+source=torch_audiomentations

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+max-line-length = 119
+exclude = scripts,*.egg,build
+select = E,W,F
+verbose = 2
+# https://pep8.readthedocs.io/en/latest/intro.html#error-codes
+format = pylint
+ignore =
+    E731  # E731 - Do not assign a lambda expression, use a def
+    W605  # W605 - invalid escape sequence '\_'. Needed for docs
+    W504  # W504 - line break after binary operator
+    W503  # W503 - line break before binary operator, need for black
+    E203  # E203 - whitespace before ':'. Opposite convention enforced by black

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade --user pip --quiet
-        python -m pip install -r requirements.txt
+        python -m pip install -r ./.github/workflows/test-requirements.txt
         python --version
         pip --version
         python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install libnsdfile
+      run: |
+        sudo apt update
+        sudo apt install libsndfile1-dev libsndfile1
+
     # FIX requirement install
     - name: Install python dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade --user pip --quiet
-        python -m pip install -r ./.github/workflows/test-requirements.txt
+        python -m pip install -r .github/workflows/test_requirements.txt
         python --version
         pip --version
         python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+# see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
+# Trigger the workflow on push or pull request
+on: [push, pull_request]
+
+jobs:
+  src-test:
+    name: unit-tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6]  #, 3.7, 3.8]
+
+    # Timeout: https://stackoverflow.com/a/59076067/4521646
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    # FIX requirement install
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade --user pip --quiet
+        python -m pip install -r requirements.txt
+        python --version
+        pip --version
+        python -m pip list
+      shell: bash
+
+    - name: Pytest and coverage
+      run: coverage run -a -m py.test tests
+
+    - name: Coverage report
+      run: |
+        coverage xml
+        bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/test_formatting.yml
+++ b/.github/workflows/test_formatting.yml
@@ -1,0 +1,25 @@
+name: Linter
+on: [push]
+
+jobs:
+  code-black:
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+
+      - name: Install Black and flake8
+        run: pip install black==19.10b0 flake8
+      - name: Run Black
+        run: python -m black --config=pyproject.toml --check torch_audiomentations tests test_fixtures
+
+      - name: Link with flake8
+        # Exit on important linting errors and warn about others.
+        run: |
+          python -m flake8  torch_audiomentations tests  --show-source --statistics  --select=F6,F7,F82,F52
+          python -m flake8 --config .flake8 --exit-zero torch_audiomentations tests --statistics

--- a/.github/workflows/test_formatting.yml
+++ b/.github/workflows/test_formatting.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: 3.6
 
       - name: Install Black and flake8
-        run: pip install black==19.10b0 flake8
+        run: pip install black==20.8b1 flake8
       - name: Run Black
         run: python -m black --config=pyproject.toml --check torch_audiomentations tests test_fixtures
 

--- a/.github/workflows/test_requirements.txt
+++ b/.github/workflows/test_requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.14,<1.18
 scipy>=1.5.2
-pytorch>=1.6.0
+torch>=1.6.0
 audiomentations>=0.11.0
 audioread>=2.1.8
 ffmpeg-python

--- a/.github/workflows/test_requirements.txt
+++ b/.github/workflows/test_requirements.txt
@@ -1,0 +1,11 @@
+numpy>=1.14,<1.18
+scipy>=1.5.2
+pytorch>=1.6.0
+audiomentations>=0.11.0
+audioread>=2.1.8
+ffmpeg-python
+librosa>=0.6.1,<=0.8
+py-cpuinfo>=7.0.0
+pytest>=5.3.4
+pytest-cov>=2.8.1
+coverage>=5.3

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+comment: false
+coverage:
+  status:
+    patch:
+      default:
+        target: 60%
+    project:
+      default:
+        target: auto  # target is the base commit coverage
+        threshold: 10%  # allow this little decrease on project
+        base: auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+]
+
+[tool.black]
+# https://github.com/psf/black
+line-length = 100
+target-version = ["py36"]
+exclude = "(.eggs|.git|.hg|.mypy_cache|.nox|.tox|.venv|.svn|_build|buck-out|build|dist)"

--- a/tests/test_impulse_response.py
+++ b/tests/test_impulse_response.py
@@ -10,7 +10,9 @@ class TestApplyImpulseResponse(unittest.TestCase):
         self.sample_rate = 16000
         self.batch_size = 32
         self.empty_input_audio = torch.empty(0)
-        self.input_audio = torch.from_numpy(load_audio(os.path.join(TEST_FIXTURES_DIR, "acoustic_guitar_0.wav"), self.sample_rate))
+        self.input_audio = torch.from_numpy(
+            load_audio(os.path.join(TEST_FIXTURES_DIR, "acoustic_guitar_0.wav"), self.sample_rate)
+        )
         self.input_audios = torch.stack([self.input_audio] * self.batch_size)
         self.ir_path = os.path.join(TEST_FIXTURES_DIR, "ir")
         self.ir_transform_guaranteed = ApplyImpulseResponse(self.ir_path, p=1.0)

--- a/torch_audiomentations/utils/file.py
+++ b/torch_audiomentations/utils/file.py
@@ -3,7 +3,7 @@ import glob
 import librosa
 
 
-SUPPORTED_EXTENSIONS = ['.wav']
+SUPPORTED_EXTENSIONS = [".wav"]
 
 
 def find_audio_files(path):
@@ -11,9 +11,10 @@ def find_audio_files(path):
     files = []
 
     for supported_extension in SUPPORTED_EXTENSIONS:
-        files.extend(glob.glob(os.path.join(path, '*' + supported_extension)))
+        files.extend(glob.glob(os.path.join(path, "*" + supported_extension)))
 
     return files
+
 
 def load_audio(audio_file_path, sample_rate):
     """Loads the audio given the path of an audio file."""


### PR DESCRIPTION
- Linting with `pylint` and `black`. We can talk about what exceptions we tolerate. Do we want to lint `scripts` as well? 
- For the unit test config, it's not fully tested but it should work. 
- I'm stuck with the requirements, how should we proceed? `environement.yml` is nice, I like it. But having a `requirements.txt` can be useful as well for non-conda users. What do you think about having `requirements.txt` and `dev-requirements.txt` and having them called in the `environement.yml` (with `-r`)? That would make a nice compromise IMO. 
- Codecov should be set up for asteroid but also not sure yet. 
