### PR TITLE
Enable variability within a batch

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 119
+max-line-length = 90
 exclude = scripts,*.egg,build
 select = E,W,F
 verbose = 2

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - scipy=1.5.2
 - pytorch=1.6.0
 - pip:
-  - audiomentations==0.11.0
+  - audiomentations==0.12.1
   - audioread==2.1.8
   - black
   - coverage==5.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,6 @@ requires = [
 
 [tool.black]
 # https://github.com/psf/black
-line-length = 100
+line-length = 90
 target-version = ["py36"]
 exclude = "(.eggs|.git|.hg|.mypy_cache|.nox|.tox|.venv|.svn|_build|buck-out|build|dist)"

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -102,6 +102,4 @@ if __name__ == "__main__":
                 )
             )
         else:
-            print(
-                "{:<32} {:.3f} s".format(run_name, np.mean(execution_times[run_name]))
-            )
+            print("{:<32} {:.3f} s".format(run_name, np.mean(execution_times[run_name])))

--- a/scripts/measure_convolve_execution_time.py
+++ b/scripts/measure_convolve_execution_time.py
@@ -54,9 +54,7 @@ if __name__ == "__main__":
 
     for i in tqdm(range(5), desc="torch FFT CPU, batch size={}".format(num_examples)):
         with timer("torch FFT CPU") as t:
-            _ = torch_convolve(
-                pytorch_samples_batch_cpu, pytorch_ir_samples_cpu
-            ).numpy()
+            _ = torch_convolve(pytorch_samples_batch_cpu, pytorch_ir_samples_cpu).numpy()
         execution_times[(t.description, num_examples)].append(t.execution_time)
 
     if is_cuda_available:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=find_packages(
         exclude=["build", "scripts", "dist", "images", "test_fixtures", "tests"]
     ),
-    install_requires=["torch"],
+    install_requires=["torch>=1.2.0"],
     python_requires=">=3.6",
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/test_background_noise.py
+++ b/tests/test_background_noise.py
@@ -10,7 +10,9 @@ class TestApplyBackgroundNoise(unittest.TestCase):
         self.batch_size = 32
         self.empty_input_audio = torch.empty(0)
         self.input_audio = torch.from_numpy(
-            load_audio(TEST_FIXTURES_DIR / "acoustic_guitar_0.wav", sample_rate=self.sample_rate)
+            load_audio(
+                TEST_FIXTURES_DIR / "acoustic_guitar_0.wav", sample_rate=self.sample_rate
+            )
         ).unsqueeze(0)
         self.input_audios = torch.stack([self.input_audio] * self.batch_size).squeeze(1)
         self.bg_path = TEST_FIXTURES_DIR / "bg"
@@ -19,43 +21,51 @@ class TestApplyBackgroundNoise(unittest.TestCase):
         self.bg_short_noise_transform_guaranteed = ApplyBackgroundNoise(
             self.bg_short_path, 20, p=1.0
         )
-        self.bg_noise_transform_no_guarantee = ApplyBackgroundNoise(self.bg_path, 20, p=0.0)
+        self.bg_noise_transform_no_guarantee = ApplyBackgroundNoise(
+            self.bg_path, 20, p=0.0
+        )
 
     def test_background_noise_no_guarantee_with_single_tensor(self):
-        mixed_input = self.bg_noise_transform_no_guarantee(self.input_audio, self.sample_rate)
+        mixed_input = self.bg_noise_transform_no_guarantee(
+            self.input_audio, self.sample_rate
+        )
         self.assertTrue(torch.equal(mixed_input, self.input_audio))
         self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
 
     def test_background_noise_no_guarantee_with_empty_tensor(self):
-        mixed_input = self.bg_noise_transform_no_guarantee(self.empty_input_audio, self.sample_rate)
+        mixed_input = self.bg_noise_transform_no_guarantee(
+            self.empty_input_audio, self.sample_rate
+        )
         self.assertTrue(torch.equal(mixed_input, self.empty_input_audio))
         self.assertEqual(mixed_input.size(0), self.empty_input_audio.size(0))
 
     def test_background_noise_guaranteed_with_zero_length_samples(self):
-        mixed_input = self.bg_noise_transform_guaranteed(self.empty_input_audio, self.sample_rate)
+        mixed_input = self.bg_noise_transform_guaranteed(
+            self.empty_input_audio, self.sample_rate
+        )
         self.assertTrue(torch.equal(mixed_input, self.empty_input_audio))
         self.assertEqual(mixed_input.size(0), self.empty_input_audio.size(0))
 
     def test_background_noise_guaranteed_with_single_tensor(self):
-        mixed_input = self.bg_noise_transform_guaranteed(self.input_audio, self.sample_rate)
+        mixed_input = self.bg_noise_transform_guaranteed(
+            self.input_audio, self.sample_rate
+        )
         self.assertFalse(torch.equal(mixed_input, self.input_audio))
         self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
         self.assertEqual(mixed_input.size(1), self.input_audio.size(1))
 
     def test_background_noise_guaranteed_with_batched_tensor(self):
-        mixed_inputs = self.bg_noise_transform_guaranteed(self.input_audios, self.sample_rate)
+        mixed_inputs = self.bg_noise_transform_guaranteed(
+            self.input_audios, self.sample_rate
+        )
         self.assertFalse(torch.equal(mixed_inputs, self.input_audios))
         self.assertEqual(mixed_inputs.size(0), self.input_audios.size(0))
         self.assertEqual(mixed_inputs.size(1), self.input_audios.size(1))
 
     def test_background_short_noise_guaranteed_with_batched_tensor(self):
-        mixed_input = self.bg_short_noise_transform_guaranteed(self.input_audio, self.sample_rate)
+        mixed_input = self.bg_short_noise_transform_guaranteed(
+            self.input_audio, self.sample_rate
+        )
         self.assertFalse(torch.equal(mixed_input, self.input_audio))
         self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
         self.assertEqual(mixed_input.size(1), self.input_audio.size(1))
-
-    def test_background_short_noise_guaranteed_with_batched_tensor(self):
-        mixed_inputs = self.bg_short_noise_transform_guaranteed(self.input_audios, self.sample_rate)
-        self.assertFalse(torch.equal(mixed_inputs, self.input_audios))
-        self.assertEqual(mixed_inputs.size(0), self.input_audios.size(0))
-        self.assertEqual(mixed_inputs.size(1), self.input_audios.size(1))

--- a/tests/test_background_noise.py
+++ b/tests/test_background_noise.py
@@ -1,6 +1,6 @@
 import torch
 import unittest
-from torch_audiomentations import ApplyBackgroundNoise, load_audio
+from torch_audiomentations import ApplyBackgroundNoise, load_audio, calculate_rms
 from .utils import TEST_FIXTURES_DIR
 
 
@@ -69,3 +69,29 @@ class TestApplyBackgroundNoise(unittest.TestCase):
         self.assertFalse(torch.equal(mixed_input, self.input_audio))
         self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
         self.assertEqual(mixed_input.size(1), self.input_audio.size(1))
+
+    def test_varying_snr_within_batch(self):
+        min_snr_in_db = 3
+        max_snr_in_db = 30
+        augment = ApplyBackgroundNoise(
+            self.bg_path, min_snr_in_db=3, max_snr_in_db=30, p=1.0
+        )
+        augmented_audios = augment(self.input_audios, self.sample_rate)
+
+        self.assertEqual(tuple(augmented_audios.shape), tuple(self.input_audios.shape))
+        self.assertFalse(torch.equal(augmented_audios, self.input_audios))
+
+        added_noises = augmented_audios - self.input_audios
+
+        actual_snr_values = []
+        for i in range(len(self.input_audios)):
+            signal_rms = calculate_rms(self.input_audios[i])
+            noise_rms = calculate_rms(added_noises[i])
+            snr_in_db = 20 * torch.log10(signal_rms / noise_rms).item()
+            self.assertGreaterEqual(snr_in_db, min_snr_in_db)
+            self.assertLessEqual(snr_in_db, max_snr_in_db)
+
+            actual_snr_values.append(snr_in_db)
+
+        self.assertLess(min(actual_snr_values), max(actual_snr_values))
+

--- a/tests/test_background_noise.py
+++ b/tests/test_background_noise.py
@@ -94,3 +94,9 @@ class TestApplyBackgroundNoise(unittest.TestCase):
             actual_snr_values.append(snr_in_db)
 
         self.assertGreater(max(actual_snr_values) - min(actual_snr_values), 13.37)
+
+    def test_invalid_params(self):
+        with self.assertRaises(ValueError):
+            augment = ApplyBackgroundNoise(
+                self.bg_path, min_snr_in_db=30, max_snr_in_db=3, p=1.0
+            )

--- a/tests/test_background_noise.py
+++ b/tests/test_background_noise.py
@@ -93,5 +93,4 @@ class TestApplyBackgroundNoise(unittest.TestCase):
 
             actual_snr_values.append(snr_in_db)
 
-        self.assertLess(min(actual_snr_values), max(actual_snr_values))
-
+        self.assertGreater(max(actual_snr_values) - min(actual_snr_values), 13.37)

--- a/tests/test_impulse_response.py
+++ b/tests/test_impulse_response.py
@@ -27,17 +27,14 @@ class TestApplyImpulseResponse(unittest.TestCase):
         mixed_input = self.ir_transform_guaranteed(self.input_audio, self.sample_rate)
         self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
         self.assertEqual(mixed_input.size(-1), self.input_audio.size(-1))
-
-        with assert_raises(AssertionError):
-            assert_array_almost_equal(mixed_input, self.input_audio)
+        self.assertFalse(torch.equal(mixed_input, self.input_audio))
 
     def test_impulse_response_guaranteed_with_batched_tensor_input(self):
         mixed_inputs = self.ir_transform_guaranteed(self.input_audios, self.sample_rate)
         self.assertEqual(mixed_inputs.size(0), self.input_audios.size(0))
         self.assertEqual(mixed_inputs.size(-1), self.input_audios.size(-1))
 
-        with assert_raises(AssertionError):
-            assert_array_almost_equal(mixed_inputs, self.input_audio)
+        self.assertFalse(torch.equal(mixed_inputs, self.input_audios))
 
     def test_impulse_response_no_guarantee_with_single_tensor_input(self):
         mixed_input = self.ir_transform_no_guarantee(self.input_audio, self.sample_rate)

--- a/tests/test_impulse_response.py
+++ b/tests/test_impulse_response.py
@@ -11,7 +11,9 @@ class TestApplyImpulseResponse(unittest.TestCase):
         self.batch_size = 32
         self.empty_input_audio = torch.empty(0)
         self.input_audio = torch.from_numpy(
-            load_audio(os.path.join(TEST_FIXTURES_DIR, "acoustic_guitar_0.wav"), self.sample_rate)
+            load_audio(
+                os.path.join(TEST_FIXTURES_DIR, "acoustic_guitar_0.wav"), self.sample_rate
+            )
         ).unsqueeze(0)
         self.input_audios = torch.stack([self.input_audio] * self.batch_size).squeeze(1)
         self.ir_path = os.path.join(TEST_FIXTURES_DIR, "ir")
@@ -37,5 +39,7 @@ class TestApplyImpulseResponse(unittest.TestCase):
         self.assertEqual(mixed_inputs.size(-1), self.input_audios.size(-1))
 
     def test_impulse_response_guaranteed_with_zero_length_samples(self):
-        mixed_inputs = self.ir_transform_guaranteed(self.empty_input_audio, self.sample_rate)
+        mixed_inputs = self.ir_transform_guaranteed(
+            self.empty_input_audio, self.sample_rate
+        )
         self.assertTrue(torch.equal(mixed_inputs, self.empty_input_audio))

--- a/tests/test_impulse_response.py
+++ b/tests/test_impulse_response.py
@@ -1,6 +1,9 @@
 import os
-import torch
 import unittest
+
+import torch
+from numpy.testing import assert_raises, assert_array_almost_equal
+
 from torch_audiomentations import ApplyImpulseResponse, load_audio
 from .utils import TEST_FIXTURES_DIR
 
@@ -22,12 +25,19 @@ class TestApplyImpulseResponse(unittest.TestCase):
 
     def test_impulse_response_guaranteed_with_single_tensor_input(self):
         mixed_input = self.ir_transform_guaranteed(self.input_audio, self.sample_rate)
-        self.assertNotEqual(mixed_input.size(-1), self.input_audio.size(-1))
+        self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
+        self.assertEqual(mixed_input.size(-1), self.input_audio.size(-1))
+
+        with assert_raises(AssertionError):
+            assert_array_almost_equal(mixed_input, self.input_audio)
 
     def test_impulse_response_guaranteed_with_batched_tensor_input(self):
         mixed_inputs = self.ir_transform_guaranteed(self.input_audios, self.sample_rate)
         self.assertEqual(mixed_inputs.size(0), self.input_audios.size(0))
-        self.assertNotEqual(mixed_inputs.size(-1), self.input_audios.size(-1))
+        self.assertEqual(mixed_inputs.size(-1), self.input_audios.size(-1))
+
+        with assert_raises(AssertionError):
+            assert_array_almost_equal(mixed_inputs, self.input_audio)
 
     def test_impulse_response_no_guarantee_with_single_tensor_input(self):
         mixed_input = self.ir_transform_no_guarantee(self.input_audio, self.sample_rate)

--- a/tests/test_polarity_inversion.py
+++ b/tests/test_polarity_inversion.py
@@ -17,8 +17,7 @@ class TestPolarityInversion(unittest.TestCase):
             samples=torch.from_numpy(samples), sample_rate=sample_rate
         ).numpy()
         assert_almost_equal(
-            inverted_samples,
-            np.array([[-1.0, -0.5, 0.25, 0.125, 0.0]], dtype=np.float32),
+            inverted_samples, np.array([[-1.0, -0.5, 0.25, 0.125, 0.0]], dtype=np.float32)
         )
         self.assertEqual(inverted_samples.dtype, np.float32)
 

--- a/tests/test_polarity_inversion.py
+++ b/tests/test_polarity_inversion.py
@@ -9,7 +9,7 @@ from torch_audiomentations import PolarityInversion
 
 class TestPolarityInversion(unittest.TestCase):
     def test_polarity_inversion(self):
-        samples = np.array([1.0, 0.5, -0.25, -0.125, 0.0], dtype=np.float32)
+        samples = np.array([[1.0, 0.5, -0.25, -0.125, 0.0]], dtype=np.float32)
         sample_rate = 16000
 
         augment = PolarityInversion(p=1.0)
@@ -17,9 +17,48 @@ class TestPolarityInversion(unittest.TestCase):
             samples=torch.from_numpy(samples), sample_rate=sample_rate
         ).numpy()
         assert_almost_equal(
-            inverted_samples, np.array([-1.0, -0.5, 0.25, 0.125, 0.0], dtype=np.float32)
+            inverted_samples,
+            np.array([[-1.0, -0.5, 0.25, 0.125, 0.0]], dtype=np.float32),
         )
         self.assertEqual(inverted_samples.dtype, np.float32)
+
+    def test_polarity_inversion_zero_probability(self):
+        samples = np.array([[1.0, 0.5, -0.25, -0.125, 0.0]], dtype=np.float32)
+        sample_rate = 16000
+
+        augment = PolarityInversion(p=0.0)
+        processed_samples = augment(
+            samples=torch.from_numpy(samples), sample_rate=sample_rate
+        ).numpy()
+        assert_almost_equal(
+            processed_samples,
+            np.array([[1.0, 0.5, -0.25, -0.125, 0.0]], dtype=np.float32),
+        )
+        self.assertEqual(processed_samples.dtype, np.float32)
+
+    def test_polarity_inversion_variability_within_batch(self):
+        samples = np.array([1.0, 0.5, 0.25, 0.125, 0.0], dtype=np.float32)
+        samples_batch = np.vstack([samples] * 10000)
+        sample_rate = 16000
+
+        augment = PolarityInversion(p=0.5)
+        processed_samples = augment(
+            samples=torch.from_numpy(samples_batch), sample_rate=sample_rate
+        ).numpy()
+
+        num_unprocessed_examples = 0
+        num_processed_examples = 0
+        for i in range(processed_samples.shape[0]):
+            if sum(processed_samples[i]) > 0:
+                num_unprocessed_examples += 1
+            else:
+                num_processed_examples += 1
+
+        self.assertEqual(num_unprocessed_examples + num_processed_examples, 10000)
+
+        print(num_processed_examples)
+        self.assertGreater(num_processed_examples, 1000)
+        self.assertLess(num_processed_examples, 9000)
 
     def test_polarity_inversion_multichannel(self):
         samples = np.array(

--- a/torch_audiomentations/__init__.py
+++ b/torch_audiomentations/__init__.py
@@ -1,6 +1,8 @@
 from .augmentations.polarity_inversion import PolarityInversion
 from .augmentations.impulse_response import ApplyImpulseResponse
 from .augmentations.background_noise import ApplyBackgroundNoise
+
+# TODO: Revise these imports
 from .utils.convolution import convolve
 from .utils.file import find_audio_files, load_audio
 from .utils.dsp import calculate_rms, calculate_desired_noise_rms, resample_audio

--- a/torch_audiomentations/augmentations/background_noise.py
+++ b/torch_audiomentations/augmentations/background_noise.py
@@ -33,7 +33,7 @@ class ApplyBackgroundNoise(BaseWaveformTransform):
         self.min_snr_in_db = min_snr_in_db
         self.max_snr_in_db = max_snr_in_db
         self.snr_distribution = torch.distributions.Uniform(
-            low=min_snr_in_db, high=max_snr_in_db
+            low=min_snr_in_db, high=max_snr_in_db, validate_args=True
         )
         self.device = device
 

--- a/torch_audiomentations/augmentations/background_noise.py
+++ b/torch_audiomentations/augmentations/background_noise.py
@@ -34,17 +34,16 @@ class ApplyBackgroundNoise(BaseWaveformTransform):
         self.max_snr_in_db = max_snr_in_db
         self.device = device
 
-    def randomize_parameters(self, samples, sample_rate: int):
-        super(ApplyBackgroundNoise, self).randomize_parameters(samples, sample_rate)
-        if self.parameters["should_apply"] and samples.size(0) > 0:
-            bg_file_paths = random.choices(self.bg_path, k=samples.size(0))
+    def randomize_parameters(self, selected_samples, sample_rate: int):
+        if self.parameters["should_apply"] and selected_samples.size(0) > 0:
+            bg_file_paths = random.choices(self.bg_path, k=selected_samples.size(0))
             bg_audios = []
             for index, bg_file_path in enumerate(bg_file_paths):
                 bg_audio_info = soundfile.info(bg_file_path, verbose=True)
                 bg_audio_num_samples = math.ceil(
                     sample_rate * bg_audio_info.frames / bg_audio_info.samplerate
                 )
-                samples_num_samples = samples[index].size(0)
+                samples_num_samples = selected_samples[index].size(0)
 
                 # ensure that background noise has the same length as the sample
                 if bg_audio_num_samples < samples_num_samples:

--- a/torch_audiomentations/augmentations/background_noise.py
+++ b/torch_audiomentations/augmentations/background_noise.py
@@ -35,59 +35,58 @@ class ApplyBackgroundNoise(BaseWaveformTransform):
         self.device = device
 
     def randomize_parameters(self, selected_samples, sample_rate: int):
-        if self.parameters["should_apply"] and selected_samples.size(0) > 0:
-            bg_file_paths = random.choices(self.bg_path, k=selected_samples.size(0))
-            bg_audios = []
-            for index, bg_file_path in enumerate(bg_file_paths):
-                bg_audio_info = soundfile.info(bg_file_path, verbose=True)
-                bg_audio_num_samples = math.ceil(
-                    sample_rate * bg_audio_info.frames / bg_audio_info.samplerate
-                )
-                samples_num_samples = selected_samples[index].size(0)
-
-                # ensure that background noise has the same length as the sample
-                if bg_audio_num_samples < samples_num_samples:
-                    bg_start_index = 0
-                    bg_stop_index = bg_audio_info.frames
-                    loaded_bg_audio_num_samples = bg_audio_num_samples
-
-                    current_bg_audio = load_audio(
-                        bg_file_path,
-                        sample_rate=sample_rate,
-                        start=bg_start_index,
-                        stop=bg_stop_index,
-                    )
-                    bg_audio = [current_bg_audio]
-
-                    # TODO: Factor out this bit that repeats the audio until the desired length
-                    #  has been reached, and then trims away any excess audio from the end
-                    while loaded_bg_audio_num_samples < samples_num_samples:
-                        current_bg_audio = bg_audio[-1]
-                        loaded_bg_audio_num_samples += current_bg_audio.shape[0]
-                        bg_audio.append(current_bg_audio)
-
-                    bg_audio = np.concatenate(bg_audio)
-                    bg_audio = bg_audio[:samples_num_samples]
-                else:
-                    factor = int(bg_audio_info.samplerate / sample_rate)
-                    max_bg_offset = max(
-                        0, bg_audio_info.frames - samples_num_samples * factor
-                    )
-                    bg_start_index = random.randint(0, max_bg_offset)
-                    bg_stop_index = bg_start_index + samples_num_samples * factor
-                    bg_audio = load_audio(
-                        bg_file_path,
-                        sample_rate=sample_rate,
-                        start=bg_start_index,
-                        stop=bg_stop_index,
-                    )
-
-                bg_audios.append(torch.from_numpy(bg_audio))
-
-            self.parameters["snr_in_db"] = random.uniform(
-                self.min_snr_in_db, self.max_snr_in_db
+        bg_file_paths = random.choices(self.bg_path, k=selected_samples.size(0))
+        bg_audios = []
+        for index, bg_file_path in enumerate(bg_file_paths):
+            bg_audio_info = soundfile.info(bg_file_path, verbose=True)
+            bg_audio_num_samples = math.ceil(
+                sample_rate * bg_audio_info.frames / bg_audio_info.samplerate
             )
-            self.parameters["bg_audios"] = torch.stack(bg_audios)
+            samples_num_samples = selected_samples[index].size(0)
+
+            # ensure that background noise has the same length as the sample
+            if bg_audio_num_samples < samples_num_samples:
+                bg_start_index = 0
+                bg_stop_index = bg_audio_info.frames
+                loaded_bg_audio_num_samples = bg_audio_num_samples
+
+                current_bg_audio = load_audio(
+                    bg_file_path,
+                    sample_rate=sample_rate,
+                    start=bg_start_index,
+                    stop=bg_stop_index,
+                )
+                bg_audio = [current_bg_audio]
+
+                # TODO: Factor out this bit that repeats the audio until the desired length
+                #  has been reached, and then trims away any excess audio from the end
+                while loaded_bg_audio_num_samples < samples_num_samples:
+                    current_bg_audio = bg_audio[-1]
+                    loaded_bg_audio_num_samples += current_bg_audio.shape[0]
+                    bg_audio.append(current_bg_audio)
+
+                bg_audio = np.concatenate(bg_audio)
+                bg_audio = bg_audio[:samples_num_samples]
+            else:
+                factor = int(bg_audio_info.samplerate / sample_rate)
+                max_bg_offset = max(
+                    0, bg_audio_info.frames - samples_num_samples * factor
+                )
+                bg_start_index = random.randint(0, max_bg_offset)
+                bg_stop_index = bg_start_index + samples_num_samples * factor
+                bg_audio = load_audio(
+                    bg_file_path,
+                    sample_rate=sample_rate,
+                    start=bg_start_index,
+                    stop=bg_stop_index,
+                )
+
+            bg_audios.append(torch.from_numpy(bg_audio))
+
+        self.parameters["snr_in_db"] = random.uniform(
+            self.min_snr_in_db, self.max_snr_in_db
+        )
+        self.parameters["bg_audios"] = torch.stack(bg_audios)
 
     def apply_transform(self, selected_samples, sample_rate: int):
         selected_samples = selected_samples.to(self.device)

--- a/torch_audiomentations/augmentations/impulse_response.py
+++ b/torch_audiomentations/augmentations/impulse_response.py
@@ -26,10 +26,9 @@ class ApplyImpulseResponse(BaseWaveformTransform):
         self.convolve_mode = convolve_mode
         self.device = device
 
-    def randomize_parameters(self, samples, sample_rate: int):
-        super(ApplyImpulseResponse, self).randomize_parameters(samples, sample_rate)
-        if self.parameters["should_apply"] and samples.size(0) > 0:
-            ir_paths = random.choices(self.ir_path, k=samples.size(0))
+    def randomize_parameters(self, selected_samples, sample_rate: int):
+        if self.parameters["should_apply"] and selected_samples.size(0) > 0:
+            ir_paths = random.choices(self.ir_path, k=selected_samples.size(0))
             ir_sounds = []
             max_ir_sound_length = 0
             for ir_path in ir_paths:

--- a/torch_audiomentations/augmentations/impulse_response.py
+++ b/torch_audiomentations/augmentations/impulse_response.py
@@ -27,24 +27,23 @@ class ApplyImpulseResponse(BaseWaveformTransform):
         self.device = device
 
     def randomize_parameters(self, selected_samples, sample_rate: int):
-        if self.parameters["should_apply"] and selected_samples.size(0) > 0:
-            ir_paths = random.choices(self.ir_path, k=selected_samples.size(0))
-            ir_sounds = []
-            max_ir_sound_length = 0
-            for ir_path in ir_paths:
-                ir_samples = load_audio(ir_path, sample_rate)
-                num_samples = len(ir_samples)
-                if num_samples > max_ir_sound_length:
-                    max_ir_sound_length = num_samples
-                ir_samples = torch.from_numpy(ir_samples)
-                ir_sounds.append(ir_samples)
-            for i in range(len(ir_sounds)):
-                placeholder = torch.zeros(
-                    size=(max_ir_sound_length,), dtype=torch.float32
-                )
-                placeholder[0 : len(ir_sounds[i])] = ir_sounds[i]
-                ir_sounds[i] = placeholder
-            self.parameters["ir_sounds"] = torch.stack(ir_sounds)
+        ir_paths = random.choices(self.ir_path, k=selected_samples.size(0))
+        ir_sounds = []
+        max_ir_sound_length = 0
+        for ir_path in ir_paths:
+            ir_samples = load_audio(ir_path, sample_rate)
+            num_samples = len(ir_samples)
+            if num_samples > max_ir_sound_length:
+                max_ir_sound_length = num_samples
+            ir_samples = torch.from_numpy(ir_samples)
+            ir_sounds.append(ir_samples)
+        for i in range(len(ir_sounds)):
+            placeholder = torch.zeros(
+                size=(max_ir_sound_length,), dtype=torch.float32
+            )
+            placeholder[0 : len(ir_sounds[i])] = ir_sounds[i]
+            ir_sounds[i] = placeholder
+        self.parameters["ir_sounds"] = torch.stack(ir_sounds)
 
     def apply_transform(self, selected_samples, sample_rate: int):
         selected_samples = selected_samples.to(self.device)

--- a/torch_audiomentations/augmentations/impulse_response.py
+++ b/torch_audiomentations/augmentations/impulse_response.py
@@ -32,9 +32,7 @@ class ApplyImpulseResponse(BaseWaveformTransform):
         max_ir_sound_length = 0
         for ir_path in ir_paths:
             ir_samples = load_audio(ir_path, sample_rate)
-            num_samples = len(ir_samples)
-            if num_samples > max_ir_sound_length:
-                max_ir_sound_length = num_samples
+            max_ir_sound_length = max(max_ir_sound_length, len(ir_samples))
             ir_samples = torch.from_numpy(ir_samples)
             ir_sounds.append(ir_samples)
         for i in range(len(ir_sounds)):

--- a/torch_audiomentations/augmentations/impulse_response.py
+++ b/torch_audiomentations/augmentations/impulse_response.py
@@ -1,18 +1,23 @@
-import numpy as np
 import random
+
 import torch
-from ..core.transforms_interface import BasicTransform, EmptyPathException
+
+from ..core.transforms_interface import BaseWaveformTransform, EmptyPathException
 from ..utils.convolution import convolve
 from ..utils.file import find_audio_files, load_audio
 
 
-class ApplyImpulseResponse(BasicTransform):
+class ApplyImpulseResponse(BaseWaveformTransform):
     """
     Convolves an input signal with an impulse response.
     """
 
-    def __init__(self, ir_path, device=torch.device("cpu"), convolve_mode="full", p=0.5):
+    def __init__(
+        self, ir_path, device=torch.device("cpu"), convolve_mode="full", p=0.5
+    ):
+        # TODO: infer device from the given samples instead
         super(ApplyImpulseResponse, self).__init__(p)
+
         self.ir_path = find_audio_files(ir_path)
 
         if len(self.ir_path) == 0:
@@ -21,7 +26,7 @@ class ApplyImpulseResponse(BasicTransform):
         self.convolve_mode = convolve_mode
         self.device = device
 
-    def randomize_parameters(self, samples, sample_rate):
+    def randomize_parameters(self, samples, sample_rate: int):
         super(ApplyImpulseResponse, self).randomize_parameters(samples, sample_rate)
         if self.parameters["should_apply"] and samples.size(0) > 0:
             ir_paths = random.choices(self.ir_path, k=samples.size(0))
@@ -35,12 +40,14 @@ class ApplyImpulseResponse(BasicTransform):
                 ir_samples = torch.from_numpy(ir_samples)
                 ir_sounds.append(ir_samples)
             for i in range(len(ir_sounds)):
-                placeholder = torch.zeros(size=(max_ir_sound_length,), dtype=torch.float32)
+                placeholder = torch.zeros(
+                    size=(max_ir_sound_length,), dtype=torch.float32
+                )
                 placeholder[0 : len(ir_sounds[i])] = ir_sounds[i]
                 ir_sounds[i] = placeholder
             self.parameters["ir_sounds"] = torch.stack(ir_sounds)
 
-    def apply(self, samples, sample_rate):
-        samples = samples.to(self.device)
+    def apply_transform(self, selected_samples, sample_rate: int):
+        selected_samples = selected_samples.to(self.device)
         ir = self.parameters["ir_sounds"].to(self.device)
-        return convolve(samples, ir, mode=self.convolve_mode)
+        return convolve(selected_samples, ir, mode=self.convolve_mode)

--- a/torch_audiomentations/augmentations/impulse_response.py
+++ b/torch_audiomentations/augmentations/impulse_response.py
@@ -12,9 +12,7 @@ class ApplyImpulseResponse(BaseWaveformTransform):
     Convolves an input signal with an impulse response.
     """
 
-    def __init__(
-        self, ir_path, device=torch.device("cpu"), convolve_mode="full", p=0.5
-    ):
+    def __init__(self, ir_path, device=torch.device("cpu"), convolve_mode="full", p=0.5):
         # TODO: infer device from the given samples instead
         super(ApplyImpulseResponse, self).__init__(p)
 
@@ -36,14 +34,14 @@ class ApplyImpulseResponse(BaseWaveformTransform):
             ir_samples = torch.from_numpy(ir_samples)
             ir_sounds.append(ir_samples)
         for i in range(len(ir_sounds)):
-            placeholder = torch.zeros(
-                size=(max_ir_sound_length,), dtype=torch.float32
-            )
+            placeholder = torch.zeros(size=(max_ir_sound_length,), dtype=torch.float32)
             placeholder[0 : len(ir_sounds[i])] = ir_sounds[i]
             ir_sounds[i] = placeholder
         self.parameters["ir_sounds"] = torch.stack(ir_sounds)
 
     def apply_transform(self, selected_samples, sample_rate: int):
         selected_samples = selected_samples.to(self.device)
+        original_length = selected_samples.shape[-1]
         ir = self.parameters["ir_sounds"].to(self.device)
-        return convolve(selected_samples, ir, mode=self.convolve_mode)
+        convolved_samples = convolve(selected_samples, ir, mode=self.convolve_mode)
+        return convolved_samples[..., :original_length]

--- a/torch_audiomentations/augmentations/polarity_inversion.py
+++ b/torch_audiomentations/augmentations/polarity_inversion.py
@@ -1,7 +1,7 @@
-from ..core.transforms_interface import BasicTransform
+from ..core.transforms_interface import BaseWaveformTransform
 
 
-class PolarityInversion(BasicTransform):
+class PolarityInversion(BaseWaveformTransform):
     """
     Flip the audio samples upside-down, reversing their polarity. In other words, multiply the
     waveform by -1, so negative values become positive, and vice versa. The result will sound
@@ -14,14 +14,14 @@ class PolarityInversion(BasicTransform):
 
     supports_multichannel = True
 
-    def __init__(self, p=0.5):
+    def __init__(self, p: float = 0.5):
         """
         :param p:
         """
         super().__init__(p)
 
-    def randomize_parameters(self, samples, sample_rate):
+    def randomize_parameters(self, samples, sample_rate: int):
         super().randomize_parameters(samples, sample_rate)
 
-    def forward(self, samples, sample_rate):
-        return -samples
+    def apply_transform(self, selected_samples, sample_rate: int):
+        return -selected_samples

--- a/torch_audiomentations/augmentations/polarity_inversion.py
+++ b/torch_audiomentations/augmentations/polarity_inversion.py
@@ -20,8 +20,5 @@ class PolarityInversion(BaseWaveformTransform):
         """
         super().__init__(p)
 
-    def randomize_parameters(self, samples, sample_rate: int):
-        super().randomize_parameters(samples, sample_rate)
-
     def apply_transform(self, selected_samples, sample_rate: int):
         return -selected_samples

--- a/torch_audiomentations/core/transforms_interface.py
+++ b/torch_audiomentations/core/transforms_interface.py
@@ -1,6 +1,7 @@
-import random
 import warnings
+
 import torch
+from torch.distributions import Bernoulli
 
 from torch_audiomentations.utils.multichannel import is_multichannel
 
@@ -13,45 +14,80 @@ class EmptyPathException(Exception):
     pass
 
 
-class BasicTransform(torch.nn.Module):
+class BaseWaveformTransform(torch.nn.Module):
     supports_multichannel = False
 
-    def __init__(self, p=0.5):
-        super(BasicTransform, self).__init__()
-        assert 0 <= p <= 1
-        self.p = p
-        self.parameters = {"should_apply": None}
+    def __init__(self, p: float = 0.5):
+        super(BaseWaveformTransform, self).__init__()
+        assert 0.0 <= p <= 1.0
+        self._p = p
+        self.parameters = {}
         self.are_parameters_frozen = False
+        self.bernoulli_distribution = Bernoulli(self._p)
 
-    def forward(self, samples, sample_rate):
+    @property
+    def p(self):
+        return self._p
+
+    @p.setter
+    def p(self, p):
+        self._p = p
+        # Update the Bernoulli distribution accordingly
+        self.bernoulli_distribution = Bernoulli(self._p)
+
+    def forward(self, samples, sample_rate: int):
+        if len(samples) == 0:
+            warnings.warn(
+                "An empty samples tensor was passed to {}".format(
+                    self.__class__.__name__
+                )
+            )
+            return samples
+
+        if is_multichannel(samples):
+            if samples.shape[1] > samples.shape[2]:
+                warnings.warn(
+                    "Multichannel audio must have channels first, not channels last. In"
+                    " other words, the shape must be (batch size, channels, samples), not"
+                    " (batch_size, samples, channels)"
+                )
+            if not self.supports_multichannel:
+                raise MultichannelAudioNotSupportedException(
+                    "{} only supports mono audio, not multichannel audio".format(
+                        self.__class__.__name__
+                    )
+                )
+
         if not self.are_parameters_frozen:
-            self.randomize_parameters(samples, sample_rate)
+            batch_size = samples.shape[0]
+            self.parameters = {
+                "should_apply": self.bernoulli_distribution.sample(
+                    sample_shape=(batch_size,)
+                ).to(torch.bool)
+            }
+            if self.parameters["should_apply"].any():
+                self.randomize_parameters(
+                    samples[self.parameters["should_apply"]], sample_rate
+                )
 
-        if self.parameters["should_apply"] and len(samples) > 0:
-            if is_multichannel(samples):
-                if samples.shape[1] > samples.shape[2]:
-                    warnings.warn(
-                        "Multichannel audio must have channels first, not channels last. In"
-                        " other words, the shape must be (batch size, channels, samples), not"
-                        " (batch_size, samples, channels)"
-                    )
-                if not self.supports_multichannel:
-                    raise MultichannelAudioNotSupportedException(
-                        "{} only supports mono audio, not multichannel audio".format(
-                            self.__class__.__name__
-                        )
-                    )
-
-            return self.apply(samples, sample_rate)
+        if self.parameters["should_apply"].any():
+            return self.apply_transform(
+                samples[self.parameters["should_apply"]], sample_rate
+            )
 
         return samples
 
-    def randomize_parameters(self, samples, sample_rate):
-        self.parameters["should_apply"] = random.random() < self.p
+    def randomize_parameters(self, selected_samples, sample_rate: int):
+        raise NotImplementedError
+
+    def apply_transform(self, selected_samples, sample_rate: int):
+        raise NotImplementedError
 
     def serialize_parameters(self):
         """Return the parameters as a JSON-serializable dict."""
-        return self.parameters
+        raise NotImplementedError
+        # TODO: Clone the params and convert any tensors into json-serializable lists
+        # return self.parameters
 
     def freeze_parameters(self):
         """

--- a/torch_audiomentations/core/transforms_interface.py
+++ b/torch_audiomentations/core/transforms_interface.py
@@ -38,9 +38,7 @@ class BaseWaveformTransform(torch.nn.Module):
     def forward(self, samples, sample_rate: int):
         if len(samples) == 0:
             warnings.warn(
-                "An empty samples tensor was passed to {}".format(
-                    self.__class__.__name__
-                )
+                "An empty samples tensor was passed to {}".format(self.__class__.__name__)
             )
             return samples
 

--- a/torch_audiomentations/core/transforms_interface.py
+++ b/torch_audiomentations/core/transforms_interface.py
@@ -71,9 +71,11 @@ class BaseWaveformTransform(torch.nn.Module):
                 )
 
         if self.parameters["should_apply"].any():
-            return self.apply_transform(
+            cloned_samples = samples.detach().clone()
+            cloned_samples[self.parameters["should_apply"]] = self.apply_transform(
                 samples[self.parameters["should_apply"]], sample_rate
             )
+            return cloned_samples
 
         return samples
 

--- a/torch_audiomentations/core/transforms_interface.py
+++ b/torch_audiomentations/core/transforms_interface.py
@@ -77,8 +77,13 @@ class BaseWaveformTransform(torch.nn.Module):
 
         return samples
 
+    def _forward_unimplemented(self, *inputs) -> None:
+        # Avoid IDE error message like "Class ... must implement all abstract methods"
+        # See also https://github.com/python/mypy/issues/8795#issuecomment-691658758
+        pass
+
     def randomize_parameters(self, selected_samples, sample_rate: int):
-        raise NotImplementedError
+        pass
 
     def apply_transform(self, selected_samples, sample_rate: int):
         raise NotImplementedError

--- a/torch_audiomentations/core/transforms_interface.py
+++ b/torch_audiomentations/core/transforms_interface.py
@@ -71,7 +71,7 @@ class BaseWaveformTransform(torch.nn.Module):
                 )
 
         if self.parameters["should_apply"].any():
-            cloned_samples = samples.detach().clone()
+            cloned_samples = samples.clone()
             cloned_samples[self.parameters["should_apply"]] = self.apply_transform(
                 samples[self.parameters["should_apply"]], sample_rate
             )

--- a/torch_audiomentations/utils/dsp.py
+++ b/torch_audiomentations/utils/dsp.py
@@ -1,5 +1,4 @@
 import librosa
-import numpy as np
 import torch
 
 
@@ -7,7 +6,7 @@ def calculate_rms(samples):
     """
     Calculates the root mean square.
 
-                Taken from https://github.com/iver56/audiomentations/blob/master/audiomentations/core/utils.py
+    Based on https://github.com/iver56/audiomentations/blob/master/audiomentations/core/utils.py
     """
     return torch.sqrt(torch.mean(torch.square(samples), -1, keepdim=True))
 
@@ -17,7 +16,7 @@ def calculate_desired_noise_rms(clean_rms, snr):
     Given the Root Mean Square (RMS) of a clean sound and a desired signal-to-noise ratio (SNR),
     calculate the desired RMS of a noise sound to be mixed in.
     Based on https://github.com/Sato-Kunihiko/audio-SNR/blob/8d2c933b6c0afe6f1203251f4877e7a1068a6130/create_mixed_audio_file.py#L20
-                Taken from https://github.com/iver56/audiomentations/blob/master/audiomentations/core/utils.py
+
     :param clean_rms: Root Mean Square (RMS) - a value between 0.0 and 1.0
     :param snr: Signal-to-Noise (SNR) Ratio in dB - typically somewhere between -20 and 60
     :return:
@@ -28,5 +27,6 @@ def calculate_desired_noise_rms(clean_rms, snr):
 
 
 def resample_audio(audio, orig_sr, target_sr):
+    # TODO: We can probably remove this function and call resample directly where needed
     """Resamples the audio to a new sampling rate."""
     return librosa.resample(audio, orig_sr, target_sr)

--- a/torch_audiomentations/utils/dsp.py
+++ b/torch_audiomentations/utils/dsp.py
@@ -21,8 +21,7 @@ def calculate_desired_noise_rms(clean_rms, snr):
     :param snr: Signal-to-Noise (SNR) Ratio in dB - typically somewhere between -20 and 60
     :return:
     """
-    a = float(snr) / 20
-    noise_rms = clean_rms / (10 ** a)
+    noise_rms = clean_rms / (10 ** (snr / 20))
     return noise_rms
 
 

--- a/torch_audiomentations/utils/file.py
+++ b/torch_audiomentations/utils/file.py
@@ -1,8 +1,9 @@
-from .dsp import resample_audio
-import os
 import glob
+import os
+
 import soundfile
 
+from .dsp import resample_audio
 
 SUPPORTED_EXTENSIONS = [".wav"]
 
@@ -18,10 +19,13 @@ def find_audio_files(path):
 
 
 def load_audio(audio_file_path, sample_rate=None, start=0, stop=None):
+    # TODO: Clarify whether start/stop is in samples or in seconds, and whether or not it
+    #  relates to the original or the resampled audio.
     """Loads the audio given the path of an audio file."""
     audio, source_sample_rate = soundfile.read(audio_file_path, start=start, stop=stop)
 
     if sample_rate:
         audio = resample_audio(audio, source_sample_rate, sample_rate)
 
+    # TODO: return sample rate as well
     return audio


### PR DESCRIPTION
Torch-audiomentations should support batch processing. Each batch contains _n_ (potentially multichannel) audio snippets.

Each audio snippet within a batch should processed with potentially different parameters. Furthermore, some of the audio snippets within a batch should remain unprocessed (this can be controlled with the `p` value). The base transform class now does a pre-selection of which audio snippets should be processed, and the implemented apply_transform would only work on those.

TODO:
* [x] Adapt and test AddBackgroundNoise
* [x] Adapt and test AddImpulseResponse

Question: How should we handle transforms that change the length of each audio snippet differently? Calculate the max audio snippet length and zero-pad all other audio snippets accordingly?

Note: This pull request also adds some TODOs that remain from #13 

Note: The reason why I renamed apply to apply_transform is that apply is already a thing in nn.Module. Didn't want to interfere with that.