### PR TITLE
Add and test CUDA support in Gain transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # torch-audiomentations
 Audio data augmentation in PyTorch. Inspired by [audiomentations](https://github.com/iver56/audiomentations).
 
+# Setup
+
+`pip install git+https://github.com/asteroid-team/torch-audiomentations`
+
+Note: torch-audiomentations will be published on PyPI for easier installation later.
+
+# Contribute
 
 Contributors welcome! 
 [Join the Asteroid's slack](https://join.slack.com/t/asteroid-dev/shared_invite/zt-cn9y85t3-QNHXKD1Et7qoyzu1Ji5bcA)

--- a/tests/test_gain.py
+++ b/tests/test_gain.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+import pytest
 import torch
 from numpy.testing import assert_almost_equal
 
@@ -97,6 +98,7 @@ class TestGain(unittest.TestCase):
         self.assertGreater(mean_gain_in_db, (-18 + 3) / 2 - 1)
         self.assertLess(mean_gain_in_db, (-18 + 3) / 2 + 1)
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
     def test_cuda_reset_distribution(self):
         samples = np.array([1.0, 0.5, 0.25, 0.125, 0.01], dtype=np.float32)
         samples_batch = np.vstack([samples] * 10000)
@@ -142,7 +144,8 @@ class TestGain(unittest.TestCase):
             augment.min_gain_in_db = 18
             augment.max_gain_in_db = 3
 
-    def test_gain_to_device(self):
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_gain_to_device_cuda(self):
         samples = np.array([[[1.0, 0.5, -0.25, -0.125, 0.0]]], dtype=np.float32)
         sample_rate = 16000
 
@@ -168,6 +171,7 @@ class TestGain(unittest.TestCase):
         )
         self.assertEqual(processed_samples.dtype, np.float32)
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
     def test_gain_cuda(self):
         samples = np.array([[[1.0, 0.5, -0.25, -0.125, 0.0]]], dtype=np.float32)
         sample_rate = 16000
@@ -187,6 +191,7 @@ class TestGain(unittest.TestCase):
         )
         self.assertEqual(processed_samples.dtype, np.float32)
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
     def test_gain_cuda_cpu(self):
         samples = np.array([[[1.0, 0.5, -0.25, -0.125, 0.0]]], dtype=np.float32)
         sample_rate = 16000

--- a/tests/test_gain.py
+++ b/tests/test_gain.py
@@ -97,6 +97,41 @@ class TestGain(unittest.TestCase):
         self.assertGreater(mean_gain_in_db, (-18 + 3) / 2 - 1)
         self.assertLess(mean_gain_in_db, (-18 + 3) / 2 + 1)
 
+    def test_cuda_reset_distribution(self):
+        samples = np.array([1.0, 0.5, 0.25, 0.125, 0.01], dtype=np.float32)
+        samples_batch = np.vstack([samples] * 10000)
+        sample_rate = 16000
+
+        augment = Gain(min_gain_in_db=-6, max_gain_in_db=6, p=0.5).cuda()
+        # Change the parameters after init
+        augment.min_gain_in_db = -18
+        augment.max_gain_in_db = 3
+        processed_samples = (
+            augment(
+                samples=torch.from_numpy(samples_batch).cuda(), sample_rate=sample_rate
+            )
+            .cpu()
+            .numpy()
+        )
+        self.assertEqual(processed_samples.dtype, np.float32)
+
+        actual_gains_in_db = []
+        for i in range(processed_samples.shape[0]):
+            if not np.allclose(processed_samples[i], samples_batch[i]):
+
+                estimated_gain_factor = np.mean(processed_samples[i] / samples_batch[i])
+                estimated_gain_factor_in_db = convert_amplitude_ratio_to_decibels(
+                    torch.tensor(estimated_gain_factor)
+                ).item()
+
+                self.assertGreaterEqual(estimated_gain_factor_in_db, -18)
+                self.assertLessEqual(estimated_gain_factor_in_db, 3)
+                actual_gains_in_db.append(estimated_gain_factor_in_db)
+
+        mean_gain_in_db = np.mean(actual_gains_in_db)
+        self.assertGreater(mean_gain_in_db, (-18 + 3) / 2 - 1)
+        self.assertLess(mean_gain_in_db, (-18 + 3) / 2 + 1)
+
     def test_invalid_distribution(self):
         with self.assertRaises(ValueError):
             Gain(min_gain_in_db=18, max_gain_in_db=-3, p=0.5)
@@ -106,3 +141,67 @@ class TestGain(unittest.TestCase):
             # Change the parameters after init
             augment.min_gain_in_db = 18
             augment.max_gain_in_db = 3
+
+    def test_gain_to_device(self):
+        samples = np.array([[[1.0, 0.5, -0.25, -0.125, 0.0]]], dtype=np.float32)
+        sample_rate = 16000
+
+        cuda_device = torch.device("cuda")
+
+        augment = Gain(min_gain_in_db=-6.000001, max_gain_in_db=-6, p=1.0).to(
+            device=cuda_device
+        )
+        processed_samples = (
+            augment(
+                samples=torch.from_numpy(samples).to(device=cuda_device),
+                sample_rate=sample_rate,
+            )
+            .cpu()
+            .numpy()
+        )
+        expected_factor = convert_decibels_to_amplitude_ratio(-6)
+        assert_almost_equal(
+            processed_samples,
+            expected_factor
+            * np.array([[[1.0, 0.5, -0.25, -0.125, 0.0]]], dtype=np.float32),
+            decimal=6,
+        )
+        self.assertEqual(processed_samples.dtype, np.float32)
+
+    def test_gain_cuda(self):
+        samples = np.array([[[1.0, 0.5, -0.25, -0.125, 0.0]]], dtype=np.float32)
+        sample_rate = 16000
+
+        augment = Gain(min_gain_in_db=-6.000001, max_gain_in_db=-6, p=1.0).cuda()
+        processed_samples = (
+            augment(samples=torch.from_numpy(samples).cuda(), sample_rate=sample_rate)
+            .cpu()
+            .numpy()
+        )
+        expected_factor = convert_decibels_to_amplitude_ratio(-6)
+        assert_almost_equal(
+            processed_samples,
+            expected_factor
+            * np.array([[[1.0, 0.5, -0.25, -0.125, 0.0]]], dtype=np.float32),
+            decimal=6,
+        )
+        self.assertEqual(processed_samples.dtype, np.float32)
+
+    def test_gain_cuda_cpu(self):
+        samples = np.array([[[1.0, 0.5, -0.25, -0.125, 0.0]]], dtype=np.float32)
+        sample_rate = 16000
+
+        augment = Gain(min_gain_in_db=-6.000001, max_gain_in_db=-6, p=1.0).cuda().cpu()
+        processed_samples = (
+            augment(samples=torch.from_numpy(samples).cpu(), sample_rate=sample_rate)
+            .cpu()
+            .numpy()
+        )
+        expected_factor = convert_decibels_to_amplitude_ratio(-6)
+        assert_almost_equal(
+            processed_samples,
+            expected_factor
+            * np.array([[[1.0, 0.5, -0.25, -0.125, 0.0]]], dtype=np.float32),
+            decimal=6,
+        )
+        self.assertEqual(processed_samples.dtype, np.float32)

--- a/torch_audiomentations/augmentations/gain.py
+++ b/torch_audiomentations/augmentations/gain.py
@@ -23,8 +23,14 @@ class Gain(BaseWaveformTransform):
         :param p:
         """
         super().__init__(p)
-        self._min_gain_in_db = min_gain_in_db
-        self._max_gain_in_db = max_gain_in_db
+        self.register_buffer(
+            name="_min_gain_in_db",
+            tensor=torch.tensor(min_gain_in_db, dtype=torch.float32),
+        )
+        self.register_buffer(
+            name="_max_gain_in_db",
+            tensor=torch.tensor(max_gain_in_db, dtype=torch.float32),
+        )
         self.gain_distribution = self.reset_distribution()
 
     def reset_distribution(self):
@@ -33,13 +39,30 @@ class Gain(BaseWaveformTransform):
         )
         return self.gain_distribution
 
+    def to(self, *args, **kwargs):
+        return_value = super().to(*args, **kwargs)
+        self.reset_distribution()
+        return return_value
+
+    def cuda(self, *args, **kwargs):
+        return_value = super().cuda(*args, **kwargs)
+        self.reset_distribution()
+        return return_value
+
+    def cpu(self, *args, **kwargs):
+        return_value = super().cpu(*args, **kwargs)
+        self.reset_distribution()
+        return return_value
+
     @property
     def min_gain_in_db(self):
         return self._min_gain_in_db
 
     @min_gain_in_db.setter
     def min_gain_in_db(self, min_gain_in_db):
-        self._min_gain_in_db = min_gain_in_db
+        self._min_gain_in_db = torch.tensor(
+            min_gain_in_db, dtype=torch.float32, device=self._min_gain_in_db.device
+        )
         self.reset_distribution()
 
     @property
@@ -48,7 +71,9 @@ class Gain(BaseWaveformTransform):
 
     @max_gain_in_db.setter
     def max_gain_in_db(self, max_gain_in_db):
-        self._max_gain_in_db = max_gain_in_db
+        self._max_gain_in_db = torch.tensor(
+            max_gain_in_db, dtype=torch.float32, device=self._max_gain_in_db.device
+        )
         self.reset_distribution()
 
     def randomize_parameters(self, selected_samples, sample_rate: int):


### PR DESCRIPTION
This fixes the following error when trying to apply Gain to CUDA tensors:

`RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`