### PR TITLE
Colored noise

### DIFF
--- a/tests/test_colored_noise.py
+++ b/tests/test_colored_noise.py
@@ -1,0 +1,81 @@
+import random
+import unittest
+
+import torch
+
+from torch_audiomentations import AddColoredNoise
+from torch_audiomentations.utils.io import Audio
+from .utils import TEST_FIXTURES_DIR
+
+
+class TestAddBackgroundNoise(unittest.TestCase):
+    def setUp(self):
+        self.sample_rate = 16000
+        self.audio = Audio(sample_rate=self.sample_rate)
+        self.batch_size = 16
+        self.empty_input_audio = torch.empty(0)
+
+        self.input_audio = self.audio(
+            TEST_FIXTURES_DIR / "acoustic_guitar_0.wav"
+        ).unsqueeze(0)
+
+        self.input_audios = torch.cat([self.input_audio] * self.batch_size, dim=0)
+        self.cl_noise_transform_guaranteed = AddColoredNoise(20, p=1.0)
+        self.cl_noise_transform_no_guarantee = AddColoredNoise(20, p=0.0)
+
+    def test_colored_noise_no_guarantee_with_single_tensor(self):
+        mixed_input = self.cl_noise_transform_no_guarantee(
+            self.input_audio, self.sample_rate
+        )
+        self.assertTrue(torch.equal(mixed_input, self.input_audio))
+        self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
+
+    def test_background_noise_no_guarantee_with_empty_tensor(self):
+        with self.assertWarns(UserWarning) as warning_context_manager:
+            mixed_input = self.cl_noise_transform_no_guarantee(
+                self.empty_input_audio, self.sample_rate
+            )
+
+        self.assertIn(
+            "An empty samples tensor was passed", str(warning_context_manager.warning)
+        )
+
+        self.assertTrue(torch.equal(mixed_input, self.empty_input_audio))
+        self.assertEqual(mixed_input.size(0), self.empty_input_audio.size(0))
+
+    def test_colored_noise_guaranteed_with_zero_length_samples(self):
+
+        with self.assertWarns(UserWarning) as warning_context_manager:
+            mixed_input = self.cl_noise_transform_guaranteed(
+                self.empty_input_audio, self.sample_rate
+            )
+
+        self.assertIn(
+            "An empty samples tensor was passed", str(warning_context_manager.warning)
+        )
+
+        self.assertTrue(torch.equal(mixed_input, self.empty_input_audio))
+        self.assertEqual(mixed_input.size(0), self.empty_input_audio.size(0))
+
+    def test_colored_noise_guaranteed_with_single_tensor(self):
+        mixed_input = self.cl_noise_transform_guaranteed(
+            self.input_audio, self.sample_rate
+        )
+        self.assertFalse(torch.equal(mixed_input, self.input_audio))
+        self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
+        self.assertEqual(mixed_input.size(1), self.input_audio.size(1))
+
+    def test_colored_noise_guaranteed_with_batched_tensor(self):
+        random.seed(42)
+        mixed_inputs = self.cl_noise_transform_guaranteed(
+            self.input_audios, self.sample_rate
+        )
+        self.assertFalse(torch.equal(mixed_inputs, self.input_audios))
+        self.assertEqual(mixed_inputs.size(0), self.input_audios.size(0))
+        self.assertEqual(mixed_inputs.size(1), self.input_audios.size(1))
+
+    def test_invalid_params(self):
+        with self.assertRaises(ValueError):
+            AddColoredNoise(min_snr_in_db=30, max_snr_in_db=3, p=1.0)
+        with self.assertRaises(ValueError):
+            AddColoredNoise(min_f_decay=2, max_f_decay=1, p=1.0)

--- a/tests/test_colored_noise.py
+++ b/tests/test_colored_noise.py
@@ -8,7 +8,7 @@ from torch_audiomentations.utils.io import Audio
 from .utils import TEST_FIXTURES_DIR
 
 
-class TestAddBackgroundNoise(unittest.TestCase):
+class TestAddColoredNoise(unittest.TestCase):
     def setUp(self):
         self.sample_rate = 16000
         self.audio = Audio(sample_rate=self.sample_rate)

--- a/torch_audiomentations/__init__.py
+++ b/torch_audiomentations/__init__.py
@@ -1,4 +1,5 @@
 from .augmentations.background_noise import AddBackgroundNoise
+from .augmentations.colored_noise import AddColoredNoise
 from .augmentations.gain import Gain
 from .augmentations.impulse_response import ApplyImpulseResponse
 from .augmentations.peak_normalization import PeakNormalization

--- a/torch_audiomentations/augmentations/colored_noise.py
+++ b/torch_audiomentations/augmentations/colored_noise.py
@@ -1,0 +1,117 @@
+from math import ceil
+
+import torch
+
+from ..core.transforms_interface import BaseWaveformTransform
+from ..utils.dsp import calculate_rms
+from ..utils.io import Audio
+
+
+def _gen_noise(f_decay, num_samples, sample_rate):
+    """
+    Generate colored noise with f_decay decay using torch.fft
+    """
+    noise = torch.normal(0, 1, (sample_rate,))
+    spec = torch.fft.rfft(noise)
+    mask = 1 / (torch.linspace(1, (sample_rate / 2) ** 0.5, spec.shape[0]) ** f_decay)
+    spec *= mask
+    noise = Audio.rms_normalize(torch.fft.irfft(spec).unsqueeze(0)).squeeze()
+    noise = torch.cat([noise] * int(ceil(num_samples / sample_rate)))
+    return noise[:num_samples]
+
+
+class AddColoredNoise(BaseWaveformTransform):
+    """
+    Add colored noises to the input audio.
+    """
+
+    supports_multichannel = True
+    requires_sample_rate = True
+
+    def __init__(
+        self,
+        min_snr_in_db: float = 3.0,
+        max_snr_in_db: float = 30.0,
+        min_f_decay: float = -2.0,
+        max_f_decay: float = 2.0,
+        mode: str = "per_example",
+        p: float = 0.5,
+        p_mode: str = None,
+        sample_rate: int = None,
+    ):
+        """
+        :param min_snr_in_db: minimum SNR in dB.
+        :param max_snr_in_db: maximium SNR in dB.
+        :param min_f_decay:
+            defines the minimum frequency power decay (1/f**f_decay).
+            Typical values are "white noise" (f_decay=0), "pink noise" (f_decay=1),
+            "brown noise" (f_decay=2), "blue noise (f_decay=-1)" and "violet noise"
+            (f_decay=-2)
+        :param max_f_decay:
+            defines the maximum power decay (1/f**f_decay) for non-white noises.
+        :param mode:
+        :param p:
+        :param p_mode:
+        :param sample_rate:
+        """
+
+        super().__init__(mode, p, p_mode, sample_rate)
+
+        self.min_snr_in_db = min_snr_in_db
+        self.max_snr_in_db = max_snr_in_db
+        if self.min_snr_in_db > self.max_snr_in_db:
+            raise ValueError("min_snr_in_db must not be greater than max_snr_in_db")
+
+        self.min_f_decay = min_f_decay
+        self.max_f_decay = max_f_decay
+        if self.min_f_decay > self.max_f_decay:
+            raise ValueError("min_f_decay must not be greater than max_f_decay")
+
+    def randomize_parameters(
+        self, selected_samples: torch.Tensor, sample_rate: int = None
+    ):
+        """
+        :params selected_samples: (batch_size, num_channels, num_samples)
+        """
+        batch_size, _, num_samples = selected_samples.shape
+
+        # (batch_size, ) SNRs
+        for param, mini, maxi in [
+            ("snr_in_db", self.min_snr_in_db, self.max_snr_in_db),
+            ("f_decay", self.min_f_decay, self.max_f_decay),
+        ]:
+            dist = torch.distributions.Uniform(
+                low=torch.tensor(
+                    mini, dtype=torch.float32, device=selected_samples.device
+                ),
+                high=torch.tensor(
+                    maxi, dtype=torch.float32, device=selected_samples.device
+                ),
+                validate_args=True,
+            )
+            self.transform_parameters[param] = dist.sample(sample_shape=(batch_size,))
+
+    def apply_transform(self, selected_samples: torch.Tensor, sample_rate: int = None):
+        batch_size, num_channels, num_samples = selected_samples.shape
+
+        if sample_rate is None:
+            sample_rate = self.sample_rate
+
+        # (batch_size, num_samples)
+        noise = torch.stack(
+            [
+                _gen_noise(
+                    self.transform_parameters["f_decay"][i], num_samples, sample_rate
+                )
+                for i in range(batch_size)
+            ]
+        ).to(selected_samples.device)
+
+        # (batch_size, num_channels)
+        noise_rms = calculate_rms(selected_samples) / (
+            10 ** (self.transform_parameters["snr_in_db"].unsqueeze(dim=-1) / 20)
+        )
+
+        return selected_samples + noise_rms.unsqueeze(-1) * noise.view(
+            batch_size, 1, num_samples
+        ).expand(-1, num_channels, -1)


### PR DESCRIPTION
Addresses #46. API is basically derived from BG noise, switching the background list by the `f_decay` parameter which defines the "color" of the noise, and is randomized. Tests were also mostly copied from BG noise, with the only addition of invalid parameter tests for the `f_power` range.

In the end, the colored noise implementation was done with plain RFFTs over one-second gaussian noise which is replicated until `num_samples`, nothing too fancy. Gray noise was left out because it has a custom "constant loudness" envelope which I couldn't think of a proper way to randomize as a parameter, so maybe it can be implemented as its own transform.