### PR TITLE
Make a shared requirements.txt for tests & build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade --user pip --quiet
-        python -m pip install -r .github/workflows/test_requirements.txt
+        python -m pip install -r .github/workflows/test_requirements.txt -r requirements.txt
         python --version
         pip --version
         python -m pip list

--- a/.github/workflows/test_requirements.txt
+++ b/.github/workflows/test_requirements.txt
@@ -1,15 +1,10 @@
 numpy>=1.14,<1.18
 scipy>=1.5.2
-torch==1.7.1
-torchaudio>=0.7.0
 audiomentations>=0.11.0
 audioread>=2.1.8
 ffmpeg-python
-julius>=0.2.3,<0.3
-librosa>=0.6.1,<=0.8
 py-cpuinfo>=7.0.0
 pytest==5.3.4
 pytest-cov==2.8.1
 coverage==4.5.2
 PyYAML>=5.3.1
-torch-pitch-shift>=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+julius>=0.2.3,<0.3
+librosa>=0.6.0
+torch>=1.7.0
+torchaudio>=0.7.0
+torch-pitch-shift>=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
+with open("requirements.txt", "r") as f:
+    requirements = f.read().split("\n")
+
 setup(
     name="torch-audiomentations",
     version=find_version("torch_audiomentations", "__init__.py"),
@@ -36,13 +39,7 @@ setup(
     packages=find_packages(
         exclude=["build", "scripts", "dist", "images", "test_fixtures", "tests"]
     ),
-    install_requires=[
-        "julius>=0.2.3,<0.3",
-        "librosa>=0.6.0",
-        "torch>=1.7.0",
-        "torchaudio>=0.7.0",
-        "torch-pitch-shift>=1.2.0",
-    ],
+    install_requires=requirements,
     extras_require={"extras": ["PyYAML"]},
     python_requires=">=3.6,<3.9.6",
     classifiers=[


### PR DESCRIPTION
Currently, updating requirements needs to be done in two files separately. Why not just make a shared requirements.txt file for the package dependencies and install them both in CI tests? I moved the `setup.py` requirements list into `requirements.txt` which is also referenced when initializing the environment in actions.