### PR TITLE
BREAKING: add support for targets as discussed in #3

### DIFF
--- a/tests/test_band_pass_filter.py
+++ b/tests/test_band_pass_filter.py
@@ -22,6 +22,6 @@ class TestBandPassFilter(unittest.TestCase):
         for _ in range(20):
             processed_samples = augment(
                 samples=torch.from_numpy(samples), sample_rate=sample_rate
-            ).numpy()
+            ).samples.numpy()
             self.assertEqual(processed_samples.shape, samples.shape)
             self.assertEqual(processed_samples.dtype, np.float32)

--- a/tests/test_band_stop_filter.py
+++ b/tests/test_band_stop_filter.py
@@ -21,6 +21,6 @@ class TestBandStopFilter(unittest.TestCase):
         augment = BandStopFilter(p=1.0)
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         self.assertEqual(processed_samples.shape, samples.shape)
         self.assertEqual(processed_samples.dtype, np.float32)

--- a/tests/test_colored_noise.py
+++ b/tests/test_colored_noise.py
@@ -13,7 +13,7 @@ class TestAddColoredNoise(unittest.TestCase):
         self.sample_rate = 16000
         self.audio = Audio(sample_rate=self.sample_rate)
         self.batch_size = 16
-        self.empty_input_audio = torch.empty(0)
+        self.empty_input_audio = torch.empty(0, 1, 16000)
 
         self.input_audio = self.audio(
             TEST_FIXTURES_DIR / "acoustic_guitar_0.wav"
@@ -26,7 +26,7 @@ class TestAddColoredNoise(unittest.TestCase):
     def test_colored_noise_no_guarantee_with_single_tensor(self):
         mixed_input = self.cl_noise_transform_no_guarantee(
             self.input_audio, self.sample_rate
-        )
+        ).samples
         self.assertTrue(torch.equal(mixed_input, self.input_audio))
         self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
 
@@ -34,7 +34,7 @@ class TestAddColoredNoise(unittest.TestCase):
         with self.assertWarns(UserWarning) as warning_context_manager:
             mixed_input = self.cl_noise_transform_no_guarantee(
                 self.empty_input_audio, self.sample_rate
-            )
+            ).samples
 
         self.assertIn(
             "An empty samples tensor was passed", str(warning_context_manager.warning)
@@ -48,7 +48,7 @@ class TestAddColoredNoise(unittest.TestCase):
         with self.assertWarns(UserWarning) as warning_context_manager:
             mixed_input = self.cl_noise_transform_guaranteed(
                 self.empty_input_audio, self.sample_rate
-            )
+            ).samples
 
         self.assertIn(
             "An empty samples tensor was passed", str(warning_context_manager.warning)
@@ -60,7 +60,7 @@ class TestAddColoredNoise(unittest.TestCase):
     def test_colored_noise_guaranteed_with_single_tensor(self):
         mixed_input = self.cl_noise_transform_guaranteed(
             self.input_audio, self.sample_rate
-        )
+        ).samples
         self.assertFalse(torch.equal(mixed_input, self.input_audio))
         self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
         self.assertEqual(mixed_input.size(1), self.input_audio.size(1))
@@ -69,7 +69,7 @@ class TestAddColoredNoise(unittest.TestCase):
         random.seed(42)
         mixed_inputs = self.cl_noise_transform_guaranteed(
             self.input_audios, self.sample_rate
-        )
+        ).samples
         self.assertFalse(torch.equal(mixed_inputs, self.input_audios))
         self.assertEqual(mixed_inputs.size(0), self.input_audios.size(0))
         self.assertEqual(mixed_inputs.size(1), self.input_audios.size(1))

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -24,7 +24,7 @@ class TestCompose(unittest.TestCase):
         )
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         expected_factor = -convert_decibels_to_amplitude_ratio(-6)
         assert_almost_equal(
             processed_samples,
@@ -41,7 +41,7 @@ class TestCompose(unittest.TestCase):
         augment = Compose([Vol(gain=-6, gain_type="db"), PolarityInversion(p=1.0)])
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         expected_factor = -convert_decibels_to_amplitude_ratio(-6)
         assert_almost_equal(
             processed_samples,
@@ -64,7 +64,7 @@ class TestCompose(unittest.TestCase):
         )
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         assert_array_equal(samples, processed_samples)
 
     def test_freeze_and_unfreeze_parameters(self):
@@ -82,17 +82,17 @@ class TestCompose(unittest.TestCase):
 
         processed_samples1 = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         augment.freeze_parameters()
         processed_samples2 = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         assert_array_equal(processed_samples1, processed_samples2)
 
         augment.unfreeze_parameters()
         processed_samples3 = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         self.assertNotEqual(processed_samples1[0, 0, 0], processed_samples3[0, 0, 0])
 
     def test_shuffle(self):
@@ -112,7 +112,7 @@ class TestCompose(unittest.TestCase):
         for i in range(100):
             processed_samples = augment(
                 samples=torch.from_numpy(samples), sample_rate=sample_rate
-            ).numpy()
+            ).samples.numpy()
 
             # Either PeakNormalization or Gain was applied last
             if processed_samples[0, 0, 0] < 0.2:
@@ -126,14 +126,8 @@ class TestCompose(unittest.TestCase):
         self.assertGreater(num_gain_last, 10)
 
     def test_supported_modes_property(self):
-        augment = Compose(
-            transforms=[
-                PeakNormalization(p=1.0),
-            ],
-        )
+        augment = Compose(transforms=[PeakNormalization(p=1.0),],)
         assert augment.supported_modes == {"per_batch", "per_example", "per_channel"}
 
-        augment = Compose(
-            transforms=[PeakNormalization(p=1.0), ShuffleChannels(p=1.0)],
-        )
+        augment = Compose(transforms=[PeakNormalization(p=1.0), ShuffleChannels(p=1.0)],)
         assert augment.supported_modes == {"per_example"}

--- a/tests/test_differentiable.py
+++ b/tests/test_differentiable.py
@@ -65,7 +65,7 @@ def test_transform_is_differentiable(augment):
     optim = SGD([samples], lr=1.0)
     for i in range(10):
         optim.zero_grad()
-        transformed = augment(samples=samples, sample_rate=sample_rate)
+        transformed = augment(samples=samples, sample_rate=sample_rate).samples
         # Compute mean absolute error
         loss = torch.mean(torch.abs(samples - transformed))
         loss.backward()

--- a/tests/test_gain.py
+++ b/tests/test_gain.py
@@ -20,7 +20,7 @@ class TestGain(unittest.TestCase):
         augment = Gain(min_gain_in_db=-6.000001, max_gain_in_db=-6, p=1.0)
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         expected_factor = convert_decibels_to_amplitude_ratio(-6)
         assert_almost_equal(
             processed_samples,
@@ -43,7 +43,7 @@ class TestGain(unittest.TestCase):
         )
         processed_samples = augment(
             samples=torch.from_numpy(samples_batch), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
 
         num_unprocessed_channels = 0
         num_processed_channels = 0
@@ -140,7 +140,7 @@ class TestGain(unittest.TestCase):
         for i in range(100):
             processed_samples = augment(
                 samples=torch.from_numpy(samples_batch), sample_rate=sample_rate
-            ).numpy()
+            ).samples.numpy()
 
             if np.allclose(processed_samples, samples_batch):
                 continue
@@ -235,7 +235,7 @@ class TestGain(unittest.TestCase):
         )
         processed_samples = augment(
             samples=torch.from_numpy(samples_batch), sample_rate=None
-        ).numpy()
+        ).samples.numpy()
 
         num_unprocessed_examples = 0
         num_processed_examples = 0
@@ -331,7 +331,7 @@ class TestGain(unittest.TestCase):
         for i in range(1000):
             processed_samples = augment(
                 samples=torch.from_numpy(samples_batch), sample_rate=sample_rate
-            ).numpy()
+            ).samples.numpy()
 
             estimated_gain_factors = processed_samples / samples_batch
             self.assertAlmostEqual(
@@ -354,7 +354,7 @@ class TestGain(unittest.TestCase):
 
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
 
         np.testing.assert_array_equal(samples, processed_samples)
 
@@ -366,7 +366,7 @@ class TestGain(unittest.TestCase):
         augment = Gain(min_gain_in_db=-6, max_gain_in_db=6, p=0.5)
         processed_samples = augment(
             samples=torch.from_numpy(samples_batch), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         self.assertEqual(processed_samples.dtype, np.float32)
 
         num_unprocessed_examples = 0
@@ -406,7 +406,7 @@ class TestGain(unittest.TestCase):
         for _ in range(100):
             processed_samples = augment(
                 samples=torch.from_numpy(samples_batch), sample_rate=sample_rate
-            ).numpy()
+            ).samples.numpy()
             self.assertEqual(processed_samples.dtype, np.float32)
 
             if np.allclose(processed_samples, samples_batch):
@@ -456,7 +456,9 @@ class TestGain(unittest.TestCase):
         # Change the parameters after init
         augment.min_gain_in_db = -18
         augment.max_gain_in_db = 3
-        processed_samples = augment(samples=torch.from_numpy(samples_batch)).numpy()
+        processed_samples = augment(
+            samples=torch.from_numpy(samples_batch)
+        ).samples.numpy()
         self.assertEqual(processed_samples.dtype, np.float32)
 
         actual_gains_in_db = []
@@ -490,7 +492,7 @@ class TestGain(unittest.TestCase):
             augment(
                 samples=torch.from_numpy(samples_batch).cuda(), sample_rate=sample_rate
             )
-            .cpu()
+            .samples.cpu()
             .numpy()
         )
         self.assertEqual(processed_samples.dtype, np.float32)
@@ -538,7 +540,7 @@ class TestGain(unittest.TestCase):
                 samples=torch.from_numpy(samples).to(device=cuda_device),
                 sample_rate=sample_rate,
             )
-            .cpu()
+            .samples.cpu()
             .numpy()
         )
         expected_factor = convert_decibels_to_amplitude_ratio(-6)
@@ -558,7 +560,7 @@ class TestGain(unittest.TestCase):
         augment = Gain(min_gain_in_db=-6.000001, max_gain_in_db=-6, p=1.0).cuda()
         processed_samples = (
             augment(samples=torch.from_numpy(samples).cuda(), sample_rate=sample_rate)
-            .cpu()
+            .samples.cpu()
             .numpy()
         )
         expected_factor = convert_decibels_to_amplitude_ratio(-6)
@@ -578,7 +580,7 @@ class TestGain(unittest.TestCase):
         augment = Gain(min_gain_in_db=-6.000001, max_gain_in_db=-6, p=1.0).cuda().cpu()
         processed_samples = (
             augment(samples=torch.from_numpy(samples).cpu(), sample_rate=sample_rate)
-            .cpu()
+            .samples.cpu()
             .numpy()
         )
         expected_factor = convert_decibels_to_amplitude_ratio(-6)

--- a/tests/test_high_pass_filter.py
+++ b/tests/test_high_pass_filter.py
@@ -22,7 +22,7 @@ class TestHighPassFilter(unittest.TestCase):
         augment = HighPassFilter(p=1.0)
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         self.assertEqual(processed_samples.shape, samples.shape)
         self.assertEqual(processed_samples.dtype, np.float32)
 
@@ -41,7 +41,7 @@ class TestHighPassFilter(unittest.TestCase):
         augment = HighPassFilter(p=1.0)
         processed_samples = (
             augment(samples=torch.from_numpy(samples).cuda(), sample_rate=sample_rate)
-            .cpu()
+            .samples.cpu()
             .numpy()
         )
         self.assertEqual(processed_samples.shape, samples.shape)

--- a/tests/test_impulse_response.py
+++ b/tests/test_impulse_response.py
@@ -49,14 +49,13 @@ def ir_transform_no_guarantee(ir_path, sample_rate):
 
 
 def test_impulse_response_guaranteed_with_single_tensor_input(ir_transform, input_audio):
-    mixed_input = ir_transform(input_audio)
+    mixed_input = ir_transform(input_audio).samples
     assert mixed_input.shape == input_audio.shape
     assert not torch.equal(mixed_input, input_audio)
 
 
 @pytest.mark.parametrize(
-    "compensate_for_propagation_delay",
-    [False, True],
+    "compensate_for_propagation_delay", [False, True],
 )
 def test_impulse_response_guaranteed_with_batched_tensor_input(
     ir_path, sample_rate, input_audios, compensate_for_propagation_delay
@@ -66,7 +65,7 @@ def test_impulse_response_guaranteed_with_batched_tensor_input(
         compensate_for_propagation_delay=compensate_for_propagation_delay,
         p=1.0,
         sample_rate=sample_rate,
-    )(input_audios)
+    )(input_audios).samples
     assert mixed_inputs.shape == input_audios.shape
     assert not torch.equal(mixed_inputs, input_audios)
 
@@ -76,7 +75,7 @@ def test_impulse_response_guaranteed_with_batched_cuda_tensor_input(
     input_audios, ir_transform
 ):
     input_audio_cuda = input_audios.cuda()
-    mixed_inputs = ir_transform(input_audio_cuda)
+    mixed_inputs = ir_transform(input_audio_cuda).samples
     assert not torch.equal(mixed_inputs, input_audio_cuda)
     assert mixed_inputs.shape == input_audio_cuda.shape
     assert mixed_inputs.dtype == input_audio_cuda.dtype
@@ -86,21 +85,21 @@ def test_impulse_response_guaranteed_with_batched_cuda_tensor_input(
 def test_impulse_response_no_guarantee_with_single_tensor_input(
     input_audio, ir_transform_no_guarantee
 ):
-    mixed_input = ir_transform_no_guarantee(input_audio)
+    mixed_input = ir_transform_no_guarantee(input_audio).samples
     assert mixed_input.shape == input_audio.shape
 
 
 def test_impulse_response_no_guarantee_with_batched_tensor_input(
     input_audios, ir_transform_no_guarantee
 ):
-    mixed_inputs = ir_transform_no_guarantee(input_audios)
+    mixed_inputs = ir_transform_no_guarantee(input_audios).samples
     assert mixed_inputs.shape == input_audios.shape
 
 
 def test_impulse_response_guaranteed_with_zero_length_samples(ir_transform):
-    empty_audio = torch.empty(0)
+    empty_audio = torch.empty(0, 1, 16000)
     with pytest.warns(UserWarning, match="An empty samples tensor was passed"):
-        mixed_inputs = ir_transform(empty_audio)
+        mixed_inputs = ir_transform(empty_audio).samples
 
     assert torch.equal(mixed_inputs, empty_audio)
 
@@ -108,7 +107,7 @@ def test_impulse_response_guaranteed_with_zero_length_samples(ir_transform):
 def test_impulse_response_access_file_paths(ir_path, sample_rate, input_audios):
 
     augment = ApplyImpulseResponse(ir_path, p=1.0, sample_rate=sample_rate)
-    mixed_inputs = augment(samples=input_audios, sample_rate=sample_rate)
+    mixed_inputs = augment(samples=input_audios, sample_rate=sample_rate).samples
 
     assert mixed_inputs.shape == input_audios.shape
 

--- a/tests/test_low_pass_filter.py
+++ b/tests/test_low_pass_filter.py
@@ -21,6 +21,6 @@ class TestLowPassFilter(unittest.TestCase):
         augment = LowPassFilter(min_cutoff_freq=200, max_cutoff_freq=7000, p=1.0)
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         self.assertEqual(processed_samples.shape, samples.shape)
         self.assertEqual(processed_samples.dtype, np.float32)

--- a/tests/test_mix.py
+++ b/tests/test_mix.py
@@ -1,0 +1,65 @@
+import os
+import random
+import shutil
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from scipy.io.wavfile import write
+
+from torch_audiomentations import Mix
+from torch_audiomentations.utils.dsp import calculate_rms
+from torch_audiomentations.utils.file import load_audio
+from .utils import TEST_FIXTURES_DIR
+
+
+class TestMix(unittest.TestCase):
+    def setUp(self):
+        self.sample_rate = 16000
+        self.guitar = (
+            torch.from_numpy(
+                load_audio(
+                    TEST_FIXTURES_DIR / "acoustic_guitar_0.wav",
+                    sample_rate=self.sample_rate,
+                )
+            )
+            .unsqueeze(0)
+            .unsqueeze(0)
+        )
+        self.noise = (
+            torch.from_numpy(
+                load_audio(
+                    TEST_FIXTURES_DIR / "bg" / "bg.wav", sample_rate=self.sample_rate,
+                )
+            )
+            .unsqueeze(0)
+            .unsqueeze(0)
+        )
+
+        common_num_samples = min(self.guitar.shape[-1], self.noise.shape[-1])
+        self.guitar = self.guitar[:, :, :common_num_samples]
+        self.noise = self.noise[:, :, :common_num_samples]
+        self.input_audios = torch.cat([self.guitar, self.noise], dim=0)
+
+    def test_varying_snr_within_batch(self):
+        min_snr_in_db = 3
+        max_snr_in_db = 30
+        augment = Mix(min_snr_in_db=min_snr_in_db, max_snr_in_db=max_snr_in_db, p=1.0)
+        mixed_audios = augment(self.input_audios, self.sample_rate).samples
+
+        self.assertEqual(tuple(mixed_audios.shape), tuple(self.input_audios.shape))
+        self.assertFalse(torch.equal(mixed_audios, self.input_audios))
+
+        added_audios = mixed_audios - self.input_audios
+
+        for i in range(len(self.input_audios)):
+            signal_rms = calculate_rms(self.input_audios[i])
+            added_rms = calculate_rms(added_audios[i])
+            snr_in_db = 20 * torch.log10(signal_rms / added_rms).item()
+            self.assertGreaterEqual(snr_in_db, min_snr_in_db)
+            self.assertLessEqual(snr_in_db, max_snr_in_db)
+

--- a/tests/test_mix.py
+++ b/tests/test_mix.py
@@ -1,15 +1,6 @@
-import os
-import random
-import shutil
-import tempfile
 import unittest
-import uuid
-from pathlib import Path
 
-import numpy as np
-import pytest
 import torch
-from scipy.io.wavfile import write
 
 from torch_audiomentations import Mix
 from torch_audiomentations.utils.dsp import calculate_rms

--- a/tests/test_peak_normalization.py
+++ b/tests/test_peak_normalization.py
@@ -23,7 +23,7 @@ class TestPeakNormalization(unittest.TestCase):
         augment = PeakNormalization(p=1.0)
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
 
         assert_almost_equal(
             processed_samples,
@@ -52,7 +52,7 @@ class TestPeakNormalization(unittest.TestCase):
         augment = PeakNormalization(apply_to="only_too_loud_sounds", p=1.0)
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
 
         assert_almost_equal(
             processed_samples,
@@ -78,7 +78,7 @@ class TestPeakNormalization(unittest.TestCase):
         augment = PeakNormalization(p=1.0)
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
 
         assert_almost_equal(
             processed_samples,
@@ -102,7 +102,7 @@ class TestPeakNormalization(unittest.TestCase):
         augment = PeakNormalization(p=1.0)
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
 
         assert_almost_equal(
             processed_samples,
@@ -127,7 +127,7 @@ class TestPeakNormalization(unittest.TestCase):
         augment = PeakNormalization(p=0.0)
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
 
         assert_equal(
             processed_samples,
@@ -157,7 +157,7 @@ class TestPeakNormalization(unittest.TestCase):
         augment = PeakNormalization(p=1.0)
         processed_samples = (
             augment(samples=torch.from_numpy(samples).cuda(), sample_rate=sample_rate)
-            .cpu()
+            .samples.cpu()
             .numpy()
         )
 
@@ -182,7 +182,7 @@ class TestPeakNormalization(unittest.TestCase):
         augment = PeakNormalization(p=0.5)
         processed_samples = augment(
             samples=torch.from_numpy(samples_batch), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         self.assertEqual(processed_samples.dtype, np.float32)
 
         num_unprocessed_examples = 0
@@ -209,11 +209,13 @@ class TestPeakNormalization(unittest.TestCase):
         sample_rate = 16000
 
         augment = PeakNormalization(p=1.0)
-        _ = augment(samples=torch.from_numpy(samples1), sample_rate=sample_rate).numpy()
+        _ = augment(
+            samples=torch.from_numpy(samples1), sample_rate=sample_rate
+        ).samples.numpy()
         augment.freeze_parameters()
         processed_samples2 = augment(
             samples=torch.from_numpy(samples2), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         augment.unfreeze_parameters()
 
         assert_almost_equal(
@@ -242,7 +244,7 @@ class TestPeakNormalization(unittest.TestCase):
         augment = PeakNormalization(apply_to="all", p=1.0)
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
 
         assert_almost_equal(
             processed_samples,

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -23,21 +23,21 @@ class TestPitchShift(unittest.TestCase):
         samples = get_example()
         aug = PitchShift(sample_rate=16000, p=1, mode="per_example")
         aug.randomize_parameters(samples)
-        results, _ = aug.apply_transform(samples)
+        results = aug.apply_transform(samples).samples
         self.assertEqual(results.shape, samples.shape)
 
     def test_per_channel_shift(self):
         samples = get_example()
         aug = PitchShift(sample_rate=16000, p=1, mode="per_channel")
         aug.randomize_parameters(samples)
-        results, _ = aug.apply_transform(samples)
+        results = aug.apply_transform(samples).samples
         self.assertEqual(results.shape, samples.shape)
 
     def test_per_batch_shift(self):
         samples = get_example()
         aug = PitchShift(sample_rate=16000, p=1, mode="per_batch")
         aug.randomize_parameters(samples)
-        results, _ = aug.apply_transform(samples)
+        results = aug.apply_transform(samples).samples
         self.assertEqual(results.shape, samples.shape)
 
     def error_raised(self):

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -21,30 +21,30 @@ def get_example():
 class TestPitchShift(unittest.TestCase):
     def test_per_example_shift(self):
         samples = get_example()
-        aug = PitchShift(16000, p=1, mode="per_example")
+        aug = PitchShift(sample_rate=16000, p=1, mode="per_example")
         aug.randomize_parameters(samples)
-        results = aug.apply_transform(samples)
+        results, _ = aug.apply_transform(samples)
         self.assertEqual(results.shape, samples.shape)
 
     def test_per_channel_shift(self):
         samples = get_example()
-        aug = PitchShift(16000, p=1, mode="per_channel")
+        aug = PitchShift(sample_rate=16000, p=1, mode="per_channel")
         aug.randomize_parameters(samples)
-        results = aug.apply_transform(samples)
+        results, _ = aug.apply_transform(samples)
         self.assertEqual(results.shape, samples.shape)
 
     def test_per_batch_shift(self):
         samples = get_example()
-        aug = PitchShift(16000, p=1, mode="per_batch")
+        aug = PitchShift(sample_rate=16000, p=1, mode="per_batch")
         aug.randomize_parameters(samples)
-        results = aug.apply_transform(samples)
+        results, _ = aug.apply_transform(samples)
         self.assertEqual(results.shape, samples.shape)
 
     def error_raised(self):
         error = False
         try:
             PitchShift(
-                16000,
+                sample_rate=16000,
                 p=1,
                 mode="per_example",
                 min_transpose_semitones=0.0,

--- a/tests/test_polarity_inversion.py
+++ b/tests/test_polarity_inversion.py
@@ -16,7 +16,7 @@ class TestPolarityInversion(unittest.TestCase):
         augment = PolarityInversion(p=1.0)
         inverted_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         assert_almost_equal(
             inverted_samples,
             np.array([[[-1.0, -0.5, 0.25, 0.125, 0.0]]], dtype=np.float32),
@@ -30,7 +30,7 @@ class TestPolarityInversion(unittest.TestCase):
         augment = PolarityInversion(p=0.0)
         processed_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         assert_almost_equal(
             processed_samples,
             np.array([[[1.0, 0.5, -0.25, -0.125, 0.0]]], dtype=np.float32),
@@ -45,7 +45,7 @@ class TestPolarityInversion(unittest.TestCase):
         augment = PolarityInversion(p=0.5)
         processed_samples = augment(
             samples=torch.from_numpy(samples_batch), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
 
         num_unprocessed_examples = 0
         num_processed_examples = 0
@@ -71,7 +71,7 @@ class TestPolarityInversion(unittest.TestCase):
         augment = PolarityInversion(p=1.0)
         inverted_samples = augment(
             samples=torch.from_numpy(samples), sample_rate=sample_rate
-        ).numpy()
+        ).samples.numpy()
         assert_almost_equal(
             inverted_samples,
             np.array(
@@ -89,7 +89,7 @@ class TestPolarityInversion(unittest.TestCase):
         augment = PolarityInversion(p=1.0).cuda()
         inverted_samples = (
             augment(samples=torch.from_numpy(samples).cuda(), sample_rate=sample_rate)
-            .cpu()
+            .samples.cpu()
             .numpy()
         )
         assert_almost_equal(

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -27,7 +27,7 @@ class TestShift:
         samples[1] += 1
 
         augment = Shift(min_shift=1, max_shift=1, shift_unit="samples", p=1.0)
-        processed_samples = augment(samples)
+        processed_samples = augment(samples).samples
 
         assert_almost_equal(
             processed_samples.cpu(),
@@ -42,7 +42,7 @@ class TestShift:
             min_shift=1, max_shift=1, shift_unit="samples", rollover=False, p=1.0
         )
 
-        processed_samples = augment(samples=samples)
+        processed_samples = augment(samples=samples).samples
         assert_almost_equal(
             processed_samples,
             [[[0, 0, 1, 2], [0, 0, 1, 2]], [[0, 1, 2, 3], [0, 1, 2, 3]]],
@@ -56,7 +56,7 @@ class TestShift:
             min_shift=-2, max_shift=-2, shift_unit="samples", rollover=True, p=1.0
         )
 
-        processed_samples = augment(samples=samples)
+        processed_samples = augment(samples=samples).samples
         assert_almost_equal(
             processed_samples,
             [[[2, 3, 0, 1], [2, 3, 0, 1]], [[3, 4, 1, 2], [3, 4, 1, 2]]],
@@ -70,7 +70,7 @@ class TestShift:
             min_shift=0.5, max_shift=0.5, shift_unit="fraction", rollover=True, p=1.0
         )
 
-        processed_samples = augment(samples=samples)
+        processed_samples = augment(samples=samples).samples
         assert_almost_equal(
             processed_samples,
             [[[2, 3, 0, 1], [2, 3, 0, 1]], [[3, 4, 1, 2], [3, 4, 1, 2]]],
@@ -83,7 +83,7 @@ class TestShift:
         augment = Shift(
             min_shift=-2, max_shift=-2, shift_unit="seconds", p=1.0, sample_rate=1
         )
-        processed_samples = augment(samples)
+        processed_samples = augment(samples).samples
 
         assert_almost_equal(
             processed_samples,
@@ -105,7 +105,7 @@ class TestShift:
             rollover=False,
         )
         # If sample_rate is specified in both __init__ and forward, then the latter will be used
-        processed_samples = augment(samples, sample_rate=forward_sample_rate)
+        processed_samples = augment(samples, sample_rate=forward_sample_rate).samples
         assert_almost_equal(
             processed_samples,
             [[[0, 0, 0, 1], [0, 0, 0, 1]], [[0, 0, 1, 2], [0, 0, 1, 2]]],
@@ -127,7 +127,7 @@ class TestShift:
 
         samples = torch.arange(4)[None, None].repeat(1000, 2, 1)
         augment = Shift(min_shift=-1, max_shift=1, shift_unit="samples", p=1.0)
-        processed_samples = augment(samples)
+        processed_samples = augment(samples).samples
 
         applied_shift_counts = {-1: 0, 0: 0, 1: 0}
         for i in range(samples.shape[0]):

--- a/tests/test_shuffle_channels.py
+++ b/tests/test_shuffle_channels.py
@@ -10,15 +10,12 @@ from torch_audiomentations.core.transforms_interface import ModeNotSupportedExce
 class TestShuffleChannels:
     def test_shuffle_mono(self):
         samples = torch.from_numpy(
-            np.array(
-                [[[1.0, -1.0, 1.0, -1.0, 1.0]]],
-                dtype=np.float32,
-            )
+            np.array([[[1.0, -1.0, 1.0, -1.0, 1.0]]], dtype=np.float32,)
         )
         augment = ShuffleChannels(p=1.0)
 
         with pytest.warns(UserWarning):
-            processed_samples = augment(samples)
+            processed_samples = augment(samples).samples
 
         assert_array_equal(samples.numpy(), processed_samples.numpy())
 
@@ -39,14 +36,13 @@ class TestShuffleChannels:
         torch.manual_seed(42)
 
         samples = np.array(
-            [[1.0, -1.0, 1.0, -1.0, 1.0], [0.1, -0.1, 0.1, -0.1, 0.1]],
-            dtype=np.float32,
+            [[1.0, -1.0, 1.0, -1.0, 1.0], [0.1, -0.1, 0.1, -0.1, 0.1]], dtype=np.float32,
         )
         samples = np.stack([samples] * 1000, axis=0)
         samples = torch.from_numpy(samples).to(device)
 
         augment = ShuffleChannels(p=1.0)
-        processed_samples = augment(samples)
+        processed_samples = augment(samples).samples
 
         orders = {"original": 0, "swapped": 0}
         for i in range(processed_samples.shape[0]):

--- a/tests/test_someof.py
+++ b/tests/test_someof.py
@@ -23,21 +23,27 @@ class TestSomeOf(unittest.TestCase):
         augment = SomeOf(2, self.transforms)
 
         self.assertEqual(len(augment.transform_indexes), 0)  # no transforms applied yet
-        processed_samples = augment(samples=self.audio, sample_rate=self.sample_rate)
+        processed_samples = augment(
+            samples=self.audio, sample_rate=self.sample_rate
+        ).samples
         self.assertEqual(len(augment.transform_indexes), 2)  # 2 transforms applied
 
     def test_someof_with_p_zero(self):
         augment = SomeOf(2, self.transforms, p=0.0)
 
         self.assertEqual(len(augment.transform_indexes), 0)  # no transforms applied yet
-        processed_samples = augment(samples=self.audio, sample_rate=self.sample_rate)
+        processed_samples = augment(
+            samples=self.audio, sample_rate=self.sample_rate
+        ).samples
         self.assertEqual(len(augment.transform_indexes), 0)  # 0 transforms applied
 
     def test_someof_tuple(self):
         augment = SomeOf((1, None), self.transforms)
 
         self.assertEqual(len(augment.transform_indexes), 0)  # no transforms applied yet
-        processed_samples = augment(samples=self.audio, sample_rate=self.sample_rate)
+        processed_samples = augment(
+            samples=self.audio, sample_rate=self.sample_rate
+        ).samples
         self.assertTrue(
             len(augment.transform_indexes) > 0
         )  # at least one transform applied
@@ -51,7 +57,7 @@ class TestSomeOf(unittest.TestCase):
         self.assertEqual(len(augment.transform_indexes), 0)  # no transforms applied yet
         processed_samples1 = augment(
             samples=samples, sample_rate=self.sample_rate
-        ).numpy()
+        ).samples.numpy()
         transform_indexes1 = augment.transform_indexes
         self.assertEqual(len(augment.transform_indexes), 2)
 
@@ -59,7 +65,7 @@ class TestSomeOf(unittest.TestCase):
 
         processed_samples2 = augment(
             samples=samples, sample_rate=self.sample_rate
-        ).numpy()
+        ).samples.numpy()
         transform_indexes2 = augment.transform_indexes
         assert_array_equal(processed_samples1, processed_samples2)
         assert_array_equal(transform_indexes1, transform_indexes2)

--- a/tests/test_time_inversion.py
+++ b/tests/test_time_inversion.py
@@ -12,7 +12,7 @@ class TestTimeInversion(unittest.TestCase):
 
     def test_single_channel(self):
         samples = self.samples.unsqueeze(0).unsqueeze(0)  # (B, C, T): (1, 1, 100)
-        processed_samples = self.augment(samples=samples, sample_rate=16000)
+        processed_samples = self.augment(samples=samples, sample_rate=16000).samples
 
         self.assertEqual(processed_samples.shape, samples.shape)
         self.assertTrue(
@@ -25,7 +25,7 @@ class TestTimeInversion(unittest.TestCase):
         samples = torch.stack([self.samples, self.samples], dim=0).unsqueeze(
             0
         )  # (B, C, T): (1, 2, 100)
-        processed_samples = self.augment(samples=samples, sample_rate=16000)
+        processed_samples = self.augment(samples=samples, sample_rate=16000).samples
 
         self.assertEqual(processed_samples.shape, samples.shape)
         self.assertTrue(

--- a/torch_audiomentations/__init__.py
+++ b/torch_audiomentations/__init__.py
@@ -6,6 +6,7 @@ from .augmentations.gain import Gain
 from .augmentations.high_pass_filter import HighPassFilter
 from .augmentations.impulse_response import ApplyImpulseResponse
 from .augmentations.low_pass_filter import LowPassFilter
+from .augmentations.mix import Mix
 from .augmentations.peak_normalization import PeakNormalization
 from .augmentations.pitch_shift import PitchShift
 from .augmentations.polarity_inversion import PolarityInversion

--- a/torch_audiomentations/augmentations/band_pass_filter.py
+++ b/torch_audiomentations/augmentations/band_pass_filter.py
@@ -1,8 +1,10 @@
 import julius
 import torch
-
+from torch import Tensor
+from typing import Optional
 from ..core.transforms_interface import BaseWaveformTransform
 from ..utils.mel_scale import convert_frequencies_to_mels, convert_mels_to_frequencies
+from ..utils.object_dict import ObjectDict
 
 
 class BandPassFilter(BaseWaveformTransform):
@@ -10,8 +12,13 @@ class BandPassFilter(BaseWaveformTransform):
     Apply band-pass filtering to the input audio.
     """
 
+    supported_modes = {"per_batch", "per_example", "per_channel"}
+
     supports_multichannel = True
     requires_sample_rate = True
+
+    supports_target = True
+    requires_target = False
 
     def __init__(
         self,
@@ -73,28 +80,25 @@ class BandPassFilter(BaseWaveformTransform):
 
     def randomize_parameters(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
     ):
         """
-        :params selected_samples: (batch_size, num_channels, num_samples)
+        :params samples: (batch_size, num_channels, num_samples)
         """
-        batch_size, _, num_samples = selected_samples.shape
+
+        batch_size, _, num_samples = samples.shape
 
         # Sample frequencies uniformly in mel space, then convert back to frequency
         def get_dist(min_freq, max_freq):
             dist = torch.distributions.Uniform(
                 low=convert_frequencies_to_mels(
-                    torch.tensor(
-                        min_freq, dtype=torch.float32, device=selected_samples.device,
-                    )
+                    torch.tensor(min_freq, dtype=torch.float32, device=samples.device,)
                 ),
                 high=convert_frequencies_to_mels(
-                    torch.tensor(
-                        max_freq, dtype=torch.float32, device=selected_samples.device,
-                    )
+                    torch.tensor(max_freq, dtype=torch.float32, device=samples.device,)
                 ),
                 validate_args=True,
             )
@@ -114,15 +118,12 @@ class BandPassFilter(BaseWaveformTransform):
 
     def apply_transform(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
-    ):
-        batch_size, num_channels, num_samples = selected_samples.shape
-
-        if sample_rate is None:
-            sample_rate = self.sample_rate
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
+    ) -> ObjectDict:
+        batch_size, num_channels, num_samples = samples.shape
 
         low_cutoffs_as_fraction_of_sample_rate = (
             self.transform_parameters["center_freq"]
@@ -136,10 +137,15 @@ class BandPassFilter(BaseWaveformTransform):
         )
         # TODO: Instead of using a for loop, perform batched compute to speed things up
         for i in range(batch_size):
-            selected_samples[i] = julius.bandpass_filter(
-                selected_samples[i],
+            samples[i] = julius.bandpass_filter(
+                samples[i],
                 cutoff_low=low_cutoffs_as_fraction_of_sample_rate[i].item(),
                 cutoff_high=high_cutoffs_as_fraction_of_sample_rate[i].item(),
             )
 
-        return selected_samples, targets
+        return ObjectDict(
+            samples=samples,
+            sample_rate=sample_rate,
+            targets=targets,
+            target_rate=target_rate,
+        )

--- a/torch_audiomentations/augmentations/band_stop_filter.py
+++ b/torch_audiomentations/augmentations/band_stop_filter.py
@@ -22,6 +22,7 @@ class BandStopFilter(BandPassFilter):
         p: float = 0.5,
         p_mode: str = None,
         sample_rate: int = None,
+        target_rate: int = None,
     ):
         """
         :param min_center_frequency: Minimum center frequency in hertz
@@ -34,6 +35,7 @@ class BandStopFilter(BandPassFilter):
         :param p:
         :param p_mode:
         :param sample_rate:
+        :param target_rate:
         """
 
         super().__init__(
@@ -41,14 +43,24 @@ class BandStopFilter(BandPassFilter):
             max_center_frequency,
             min_bandwidth_fraction,
             max_bandwidth_fraction,
-            mode,
-            p,
-            p_mode,
-            sample_rate,
+            mode=mode,
+            p=p,
+            p_mode=p_mode,
+            sample_rate=sample_rate,
+            target_rate=target_rate,
         )
 
-    def apply_transform(self, selected_samples: torch.Tensor, sample_rate: int = None):
-        band_pass_filtered_samples = super().apply_transform(
-            selected_samples.clone(), sample_rate
+    def apply_transform(
+        self,
+        selected_samples: torch.Tensor,
+        sample_rate: int = None,
+        targets: torch.Tensor = None,
+        target_rate: int = None,
+    ):
+        band_pass_filtered_samples, band_pass_filtered_targets = super().apply_transform(
+            selected_samples.clone(),
+            sample_rate,
+            targets=targets.clone() if targets is not None else None,
+            target_rate=target_rate,
         )
-        return selected_samples - band_pass_filtered_samples
+        return selected_samples - band_pass_filtered_samples, band_pass_filtered_targets

--- a/torch_audiomentations/augmentations/band_stop_filter.py
+++ b/torch_audiomentations/augmentations/band_stop_filter.py
@@ -1,6 +1,8 @@
-import torch
+from torch import Tensor
+from typing import Optional
 
 from ..augmentations.band_pass_filter import BandPassFilter
+from ..utils.object_dict import ObjectDict
 
 
 class BandStopFilter(BandPassFilter):
@@ -8,9 +10,6 @@ class BandStopFilter(BandPassFilter):
     Apply band-stop filtering to the input audio. Also known as notch filter,
     band reject filter and frequency mask.
     """
-
-    supports_multichannel = True
-    requires_sample_rate = True
 
     def __init__(
         self,
@@ -52,15 +51,18 @@ class BandStopFilter(BandPassFilter):
 
     def apply_transform(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
-    ):
-        band_pass_filtered_samples, band_pass_filtered_targets = super().apply_transform(
-            selected_samples.clone(),
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
+    ) -> ObjectDict:
+
+        perturbed = super().apply_transform(
+            samples.clone(),
             sample_rate,
             targets=targets.clone() if targets is not None else None,
             target_rate=target_rate,
         )
-        return selected_samples - band_pass_filtered_samples, band_pass_filtered_targets
+
+        perturbed.samples = samples - perturbed.samples
+        return perturbed

--- a/torch_audiomentations/augmentations/colored_noise.py
+++ b/torch_audiomentations/augmentations/colored_noise.py
@@ -1,10 +1,13 @@
 import torch
+from torch import Tensor
+from typing import Optional
 from math import ceil
 
 from torch_audiomentations.utils.fft import rfft, irfft
 from ..core.transforms_interface import BaseWaveformTransform
 from ..utils.dsp import calculate_rms
 from ..utils.io import Audio
+from ..utils.object_dict import ObjectDict
 
 
 def _gen_noise(f_decay, num_samples, sample_rate, device):
@@ -33,8 +36,13 @@ class AddColoredNoise(BaseWaveformTransform):
     Add colored noises to the input audio.
     """
 
+    supported_modes = {"per_batch", "per_example", "per_channel"}
+
     supports_multichannel = True
     requires_sample_rate = True
+
+    supports_target = True
+    requires_target = False
 
     def __init__(
         self,
@@ -85,15 +93,15 @@ class AddColoredNoise(BaseWaveformTransform):
 
     def randomize_parameters(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
     ):
         """
         :params selected_samples: (batch_size, num_channels, num_samples)
         """
-        batch_size, _, num_samples = selected_samples.shape
+        batch_size, _, num_samples = samples.shape
 
         # (batch_size, ) SNRs
         for param, mini, maxi in [
@@ -101,27 +109,21 @@ class AddColoredNoise(BaseWaveformTransform):
             ("f_decay", self.min_f_decay, self.max_f_decay),
         ]:
             dist = torch.distributions.Uniform(
-                low=torch.tensor(
-                    mini, dtype=torch.float32, device=selected_samples.device
-                ),
-                high=torch.tensor(
-                    maxi, dtype=torch.float32, device=selected_samples.device
-                ),
+                low=torch.tensor(mini, dtype=torch.float32, device=samples.device),
+                high=torch.tensor(maxi, dtype=torch.float32, device=samples.device),
                 validate_args=True,
             )
             self.transform_parameters[param] = dist.sample(sample_shape=(batch_size,))
 
     def apply_transform(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
-    ):
-        batch_size, num_channels, num_samples = selected_samples.shape
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
+    ) -> ObjectDict:
 
-        if sample_rate is None:
-            sample_rate = self.sample_rate
+        batch_size, num_channels, num_samples = samples.shape
 
         # (batch_size, num_samples)
         noise = torch.stack(
@@ -130,20 +132,22 @@ class AddColoredNoise(BaseWaveformTransform):
                     self.transform_parameters["f_decay"][i],
                     num_samples,
                     sample_rate,
-                    selected_samples.device,
+                    samples.device,
                 )
                 for i in range(batch_size)
             ]
         )
 
         # (batch_size, num_channels)
-        noise_rms = calculate_rms(selected_samples) / (
+        noise_rms = calculate_rms(samples) / (
             10 ** (self.transform_parameters["snr_in_db"].unsqueeze(dim=-1) / 20)
         )
 
-        return (
-            selected_samples
+        return ObjectDict(
+            samples=samples
             + noise_rms.unsqueeze(-1)
             * noise.view(batch_size, 1, num_samples).expand(-1, num_channels, -1),
-            targets,
+            sample_rate=sample_rate,
+            targets=targets,
+            target_rate=target_rate,
         )

--- a/torch_audiomentations/augmentations/gain.py
+++ b/torch_audiomentations/augmentations/gain.py
@@ -1,8 +1,10 @@
 import torch
-import typing
+from torch import Tensor
+from typing import Optional
 
 from ..core.transforms_interface import BaseWaveformTransform
 from ..utils.dsp import convert_decibels_to_amplitude_ratio
+from ..utils.object_dict import ObjectDict
 
 
 class Gain(BaseWaveformTransform):
@@ -15,7 +17,13 @@ class Gain(BaseWaveformTransform):
     See also https://en.wikipedia.org/wiki/Clipping_(audio)#Digital_clipping
     """
 
+    supported_modes = {"per_batch", "per_example", "per_channel"}
+
+    supports_multichannel = True
     requires_sample_rate = False
+
+    supports_target = True
+    requires_target = False
 
     def __init__(
         self,
@@ -23,9 +31,9 @@ class Gain(BaseWaveformTransform):
         max_gain_in_db: float = 6.0,
         mode: str = "per_example",
         p: float = 0.5,
-        p_mode: typing.Optional[str] = None,
-        sample_rate: typing.Optional[int] = None,
-        target_rate: typing.Optional[int] = None,
+        p_mode: Optional[str] = None,
+        sample_rate: Optional[int] = None,
+        target_rate: Optional[int] = None,
     ):
         super().__init__(
             mode=mode,
@@ -41,21 +49,21 @@ class Gain(BaseWaveformTransform):
 
     def randomize_parameters(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
     ):
         distribution = torch.distributions.Uniform(
             low=torch.tensor(
-                self.min_gain_in_db, dtype=torch.float32, device=selected_samples.device
+                self.min_gain_in_db, dtype=torch.float32, device=samples.device
             ),
             high=torch.tensor(
-                self.max_gain_in_db, dtype=torch.float32, device=selected_samples.device
+                self.max_gain_in_db, dtype=torch.float32, device=samples.device
             ),
             validate_args=True,
         )
-        selected_batch_size = selected_samples.size(0)
+        selected_batch_size = samples.size(0)
         self.transform_parameters["gain_factors"] = (
             convert_decibels_to_amplitude_ratio(
                 distribution.sample(sample_shape=(selected_batch_size,))
@@ -66,9 +74,16 @@ class Gain(BaseWaveformTransform):
 
     def apply_transform(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
-    ):
-        return selected_samples * self.transform_parameters["gain_factors"], targets
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
+    ) -> ObjectDict:
+
+        return ObjectDict(
+            samples=samples * self.transform_parameters["gain_factors"],
+            sample_rate=sample_rate,
+            targets=targets,
+            target_rate=target_rate,
+        )
+

--- a/torch_audiomentations/augmentations/gain.py
+++ b/torch_audiomentations/augmentations/gain.py
@@ -25,15 +25,26 @@ class Gain(BaseWaveformTransform):
         p: float = 0.5,
         p_mode: typing.Optional[str] = None,
         sample_rate: typing.Optional[int] = None,
+        target_rate: typing.Optional[int] = None,
     ):
-        super().__init__(mode, p, p_mode, sample_rate)
+        super().__init__(
+            mode=mode,
+            p=p,
+            p_mode=p_mode,
+            sample_rate=sample_rate,
+            target_rate=target_rate,
+        )
         self.min_gain_in_db = min_gain_in_db
         self.max_gain_in_db = max_gain_in_db
         if self.min_gain_in_db >= self.max_gain_in_db:
             raise ValueError("max_gain_in_db must be higher than min_gain_in_db")
 
     def randomize_parameters(
-        self, selected_samples, sample_rate: typing.Optional[int] = None
+        self,
+        selected_samples: torch.Tensor,
+        sample_rate: int = None,
+        targets: torch.Tensor = None,
+        target_rate: int = None,
     ):
         distribution = torch.distributions.Uniform(
             low=torch.tensor(
@@ -53,5 +64,11 @@ class Gain(BaseWaveformTransform):
             .unsqueeze(1)
         )
 
-    def apply_transform(self, selected_samples, sample_rate: typing.Optional[int] = None):
-        return selected_samples * self.transform_parameters["gain_factors"]
+    def apply_transform(
+        self,
+        selected_samples: torch.Tensor,
+        sample_rate: int = None,
+        targets: torch.Tensor = None,
+        target_rate: int = None,
+    ):
+        return selected_samples * self.transform_parameters["gain_factors"], targets

--- a/torch_audiomentations/augmentations/high_pass_filter.py
+++ b/torch_audiomentations/augmentations/high_pass_filter.py
@@ -19,6 +19,7 @@ class HighPassFilter(LowPassFilter):
         p: float = 0.5,
         p_mode: str = None,
         sample_rate: int = None,
+        target_rate: int = None,
     ):
         """
         :param min_cutoff_freq: Minimum cutoff frequency in hertz
@@ -27,11 +28,30 @@ class HighPassFilter(LowPassFilter):
         :param p:
         :param p_mode:
         :param sample_rate:
+        :param target_rate:
         """
-        super().__init__(min_cutoff_freq, max_cutoff_freq, mode, p, p_mode, sample_rate)
 
-    def apply_transform(self, selected_samples: torch.Tensor, sample_rate: int = None):
-        low_pass_filtered_samples = super().apply_transform(
-            selected_samples.clone(), sample_rate
+        super().__init__(
+            min_cutoff_freq,
+            max_cutoff_freq,
+            mode=mode,
+            p=p,
+            p_mode=p_mode,
+            sample_rate=sample_rate,
+            target_rate=target_rate,
         )
-        return selected_samples - low_pass_filtered_samples
+
+    def apply_transform(
+        self,
+        selected_samples: torch.Tensor,
+        sample_rate: int = None,
+        targets: torch.Tensor = None,
+        target_rate: int = None,
+    ):
+        low_pass_filtered_samples, low_pass_filtered_targets = super().apply_transform(
+            selected_samples.clone(),
+            sample_rate,
+            targets=targets.clone() if targets is not None else None,
+            target_rate=target_rate,
+        )
+        return selected_samples - low_pass_filtered_samples, low_pass_filtered_targets

--- a/torch_audiomentations/augmentations/high_pass_filter.py
+++ b/torch_audiomentations/augmentations/high_pass_filter.py
@@ -1,15 +1,14 @@
-import torch
+from torch import Tensor
+from typing import Optional
 
 from ..augmentations.low_pass_filter import LowPassFilter
+from ..utils.object_dict import ObjectDict
 
 
 class HighPassFilter(LowPassFilter):
     """
     Apply high-pass filtering to the input audio.
     """
-
-    supports_multichannel = True
-    requires_sample_rate = True
 
     def __init__(
         self,
@@ -43,15 +42,18 @@ class HighPassFilter(LowPassFilter):
 
     def apply_transform(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
-    ):
-        low_pass_filtered_samples, low_pass_filtered_targets = super().apply_transform(
-            selected_samples.clone(),
-            sample_rate,
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
+    ) -> ObjectDict:
+
+        perturbed = super().apply_transform(
+            samples=samples.clone(),
+            sample_rate=sample_rate,
             targets=targets.clone() if targets is not None else None,
             target_rate=target_rate,
         )
-        return selected_samples - low_pass_filtered_samples, low_pass_filtered_targets
+
+        perturbed.samples = samples - perturbed.samples
+        return perturbed

--- a/torch_audiomentations/augmentations/low_pass_filter.py
+++ b/torch_audiomentations/augmentations/low_pass_filter.py
@@ -21,6 +21,7 @@ class LowPassFilter(BaseWaveformTransform):
         p: float = 0.5,
         p_mode: str = None,
         sample_rate: int = None,
+        target_rate: int = None,
     ):
         """
         :param min_cutoff_freq: Minimum cutoff frequency in hertz
@@ -30,7 +31,13 @@ class LowPassFilter(BaseWaveformTransform):
         :param p_mode:
         :param sample_rate:
         """
-        super().__init__(mode, p, p_mode, sample_rate)
+        super().__init__(
+            mode=mode,
+            p=p,
+            p_mode=p_mode,
+            sample_rate=sample_rate,
+            target_rate=target_rate,
+        )
 
         self.min_cutoff_freq = min_cutoff_freq
         self.max_cutoff_freq = max_cutoff_freq
@@ -38,7 +45,11 @@ class LowPassFilter(BaseWaveformTransform):
             raise ValueError("min_cutoff_freq must not be greater than max_cutoff_freq")
 
     def randomize_parameters(
-        self, selected_samples: torch.Tensor, sample_rate: int = None
+        self,
+        selected_samples: torch.Tensor,
+        sample_rate: int = None,
+        targets: torch.Tensor = None,
+        target_rate: int = None,
     ):
         """
         :params selected_samples: (batch_size, num_channels, num_samples)
@@ -67,7 +78,13 @@ class LowPassFilter(BaseWaveformTransform):
             dist.sample(sample_shape=(batch_size,))
         )
 
-    def apply_transform(self, selected_samples: torch.Tensor, sample_rate: int = None):
+    def apply_transform(
+        self,
+        selected_samples: torch.Tensor,
+        sample_rate: int = None,
+        targets: torch.Tensor = None,
+        target_rate: int = None,
+    ):
         batch_size, num_channels, num_samples = selected_samples.shape
 
         if sample_rate is None:
@@ -82,4 +99,4 @@ class LowPassFilter(BaseWaveformTransform):
                 selected_samples[i], cutoffs_as_fraction_of_sample_rate[i].item()
             )
 
-        return selected_samples
+        return selected_samples, targets

--- a/torch_audiomentations/augmentations/mix.py
+++ b/torch_audiomentations/augmentations/mix.py
@@ -48,11 +48,17 @@ class Mix(BaseWaveformTransform):
         if self.min_snr_in_db > self.max_snr_in_db:
             raise ValueError("min_snr_in_db must not be greater than max_snr_in_db")
 
-        # TODO: make it configuration via a "string"
         self.mix_target = mix_target
-        self._mix_target = lambda target, background_target, snr: torch.maximize(
-            target, background_target
-        )
+        if mix_target == "original":
+            self._mix_target = lambda target, background_target, snr: target
+
+        elif mix_target == "union":
+            self._mix_target = lambda target, background_target, snr: torch.maximize(
+                target, background_target
+            )
+
+        else:
+            raise ValueError("mix_target must be one of 'original' or 'union'.")
 
     def randomize_parameters(
         self,

--- a/torch_audiomentations/augmentations/mix.py
+++ b/torch_audiomentations/augmentations/mix.py
@@ -1,0 +1,110 @@
+from typing import Optional
+import torch
+
+from ..core.transforms_interface import BaseWaveformTransform
+from ..utils.dsp import calculate_rms
+from ..utils.io import Audio
+
+
+class Mix(BaseWaveformTransform):
+    """
+    Create a new sample by mixing it with another random sample from the same batch
+
+    Signal-to-noise ratio (where "noise" is the second random sample) is selected
+    randomly between `min_snr_in_db` and `max_snr_in_db`.
+
+    `mix_target` controls how resulting targets are generated. It can be one of 
+    "original" (targets are those of the original sample) or "union" (targets are the 
+    union of original and overlapping targets)
+
+    """
+
+    supports_multichannel = True
+    supported_modes = {"per_example", "per_channel"}
+    requires_sample_rate = False
+    requires_targets = False
+    requires_target_rate = False
+
+    def __init__(
+        self,
+        min_snr_in_db: float = 0.0,
+        max_snr_in_db: float = 5.0,
+        mix_target: str = "union",
+        mode: str = "per_example",
+        p: float = 0.5,
+        p_mode: str = None,
+        sample_rate: int = None,
+        target_rate: int = None,
+    ):
+        super().__init__(
+            mode=mode,
+            p=p,
+            p_mode=p_mode,
+            sample_rate=sample_rate,
+            target_rate=target_rate,
+        )
+        self.min_snr_in_db = min_snr_in_db
+        self.max_snr_in_db = max_snr_in_db
+        if self.min_snr_in_db > self.max_snr_in_db:
+            raise ValueError("min_snr_in_db must not be greater than max_snr_in_db")
+
+        # TODO: make it configuration via a "string"
+        self.mix_target = mix_target
+        self._mix_target = lambda target, background_target, snr: torch.maximize(
+            target, background_target
+        )
+
+    def randomize_parameters(
+        self,
+        selected_samples,
+        sample_rate: Optional[int] = None,
+        targets=None,
+        target_rate: Optional[int] = None,
+    ):
+
+        batch_size, num_channels, num_samples = selected_samples.shape
+        snr_distribution = torch.distributions.Uniform(
+            low=torch.tensor(
+                self.min_snr_in_db, dtype=torch.float32, device=selected_samples.device,
+            ),
+            high=torch.tensor(
+                self.max_snr_in_db, dtype=torch.float32, device=selected_samples.device,
+            ),
+            validate_args=True,
+        )
+
+        # randomize SNRs
+        self.transform_parameters["snr_in_db"] = snr_distribution.sample(
+            sample_shape=(batch_size,)
+        )
+
+        # randomize index of second sample
+        self.transform_parameters["sample_idx"] = torch.randint(
+            0, batch_size, (batch_size,), device=selected_samples.device,
+        )
+
+    def apply_transform(
+        self,
+        selected_samples: torch.Tensor,
+        sample_rate: int = None,
+        targets: torch.Tensor = None,
+        target_rate: int = None,
+    ):
+
+        snr = self.transform_parameters["snr_in_db"]
+        idx = self.transform_parameters["sample_idx"]
+
+        background_samples = Audio.rms_normalize(selected_samples[idx])
+        background_rms = calculate_rms(selected_samples) / (
+            10 ** (snr.unsqueeze(dim=-1) / 20)
+        )
+
+        perturbed_samples = (
+            selected_samples + background_rms.unsqueeze(-1) * background_samples
+        )
+        if targets is None:
+            return perturbed_samples
+
+        background_targets = targets[idx]
+        perturbed_targets = self._mix_target(targets, background_targets, snr)
+        return perturbed_samples, perturbed_targets

--- a/torch_audiomentations/augmentations/mix.py
+++ b/torch_audiomentations/augmentations/mix.py
@@ -53,7 +53,7 @@ class Mix(BaseWaveformTransform):
             self._mix_target = lambda target, background_target, snr: target
 
         elif mix_target == "union":
-            self._mix_target = lambda target, background_target, snr: torch.maximize(
+            self._mix_target = lambda target, background_target, snr: torch.maximum(
                 target, background_target
             )
 

--- a/torch_audiomentations/augmentations/peak_normalization.py
+++ b/torch_audiomentations/augmentations/peak_normalization.py
@@ -1,7 +1,10 @@
 import torch
 import typing
+from typing import Optional
+from torch import Tensor
 
 from ..core.transforms_interface import BaseWaveformTransform
+from ..utils.object_dict import ObjectDict
 
 
 class PeakNormalization(BaseWaveformTransform):
@@ -16,7 +19,13 @@ class PeakNormalization(BaseWaveformTransform):
     untouched.
     """
 
+    supported_modes = {"per_batch", "per_example", "per_channel"}
+
+    supports_multichannel = True
     requires_sample_rate = False
+
+    supports_target = True
+    requires_target = False
 
     def __init__(
         self,
@@ -39,13 +48,13 @@ class PeakNormalization(BaseWaveformTransform):
 
     def randomize_parameters(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
     ):
         # Compute the most extreme value of each multichannel audio snippet in the batch
-        most_extreme_values, _ = torch.max(torch.abs(selected_samples), dim=-1)
+        most_extreme_values, _ = torch.max(torch.abs(samples), dim=-1)
         most_extreme_values, _ = torch.max(most_extreme_values, dim=-1)
 
         if self.apply_to == "all":
@@ -68,13 +77,20 @@ class PeakNormalization(BaseWaveformTransform):
 
     def apply_transform(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
-    ):
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
+    ) -> ObjectDict:
+
         if "divisors" in self.transform_parameters:
-            selected_samples[
-                self.transform_parameters["selector"]
-            ] /= self.transform_parameters["divisors"]
-        return selected_samples, targets
+            samples[self.transform_parameters["selector"]] /= self.transform_parameters[
+                "divisors"
+            ]
+
+        return ObjectDict(
+            samples=samples,
+            sample_rate=sample_rate,
+            targets=targets,
+            target_rate=target_rate,
+        )

--- a/torch_audiomentations/augmentations/polarity_inversion.py
+++ b/torch_audiomentations/augmentations/polarity_inversion.py
@@ -1,4 +1,5 @@
 import typing
+import torch
 
 from ..core.transforms_interface import BaseWaveformTransform
 
@@ -23,8 +24,21 @@ class PolarityInversion(BaseWaveformTransform):
         p: float = 0.5,
         p_mode: typing.Optional[str] = None,
         sample_rate: typing.Optional[int] = None,
+        target_rate: typing.Optional[int] = None,
     ):
-        super().__init__(mode, p, p_mode, sample_rate)
+        super().__init__(
+            mode=mode,
+            p=p,
+            p_mode=p_mode,
+            sample_rate=sample_rate,
+            target_rate=target_rate,
+        )
 
-    def apply_transform(self, selected_samples, sample_rate: typing.Optional[int] = None):
-        return -selected_samples
+    def apply_transform(
+        self,
+        selected_samples: torch.Tensor,
+        sample_rate: int = None,
+        targets: torch.Tensor = None,
+        target_rate: int = None,
+    ):
+        return -selected_samples, targets

--- a/torch_audiomentations/augmentations/polarity_inversion.py
+++ b/torch_audiomentations/augmentations/polarity_inversion.py
@@ -1,7 +1,8 @@
-import typing
-import torch
+from torch import Tensor
+from typing import Optional
 
 from ..core.transforms_interface import BaseWaveformTransform
+from ..utils.object_dict import ObjectDict
 
 
 class PolarityInversion(BaseWaveformTransform):
@@ -15,16 +16,21 @@ class PolarityInversion(BaseWaveformTransform):
     training phase-aware machine learning models.
     """
 
+    supported_modes = {"per_batch", "per_example", "per_channel"}
+
     supports_multichannel = True
     requires_sample_rate = False
+
+    supports_target = True
+    requires_target = False
 
     def __init__(
         self,
         mode: str = "per_example",
         p: float = 0.5,
-        p_mode: typing.Optional[str] = None,
-        sample_rate: typing.Optional[int] = None,
-        target_rate: typing.Optional[int] = None,
+        p_mode: Optional[str] = None,
+        sample_rate: Optional[int] = None,
+        target_rate: Optional[int] = None,
     ):
         super().__init__(
             mode=mode,
@@ -36,9 +42,16 @@ class PolarityInversion(BaseWaveformTransform):
 
     def apply_transform(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
-    ):
-        return -selected_samples, targets
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
+    ) -> ObjectDict:
+
+        return ObjectDict(
+            samples=-samples,
+            sample_rate=sample_rate,
+            targets=targets,
+            target_rate=target_rate,
+        )
+

--- a/torch_audiomentations/augmentations/shuffle_channels.py
+++ b/torch_audiomentations/augmentations/shuffle_channels.py
@@ -24,11 +24,22 @@ class ShuffleChannels(BaseWaveformTransform):
         p: float = 0.5,
         p_mode: typing.Optional[str] = None,
         sample_rate: typing.Optional[int] = None,
+        target_rate: typing.Optional[int] = None,
     ):
-        super().__init__(mode, p, p_mode, sample_rate)
+        super().__init__(
+            mode=mode,
+            p=p,
+            p_mode=p_mode,
+            sample_rate=sample_rate,
+            target_rate=target_rate,
+        )
 
     def randomize_parameters(
-        self, selected_samples, sample_rate: typing.Optional[int] = None
+        self,
+        selected_samples: torch.Tensor,
+        sample_rate: int = None,
+        targets: torch.Tensor = None,
+        target_rate: int = None,
     ):
         batch_size = selected_samples.shape[0]
         num_channels = selected_samples.shape[1]
@@ -40,15 +51,26 @@ class ShuffleChannels(BaseWaveformTransform):
             permutations[i] = torch.randperm(num_channels, device=selected_samples.device)
         self.transform_parameters["permutations"] = permutations
 
-    def apply_transform(self, selected_samples, sample_rate: typing.Optional[int] = None):
+    def apply_transform(
+        self,
+        selected_samples: torch.Tensor,
+        sample_rate: int = None,
+        targets: torch.Tensor = None,
+        target_rate: int = None,
+    ):
+
         if selected_samples.shape[1] == 1:
             warnings.warn(
                 "Mono audio was passed to ShuffleChannels - there are no channels to shuffle."
                 " The input will be returned unchanged."
             )
-            return selected_samples
+            return selected_samples, targets
+
         for i in range(selected_samples.size(0)):
             selected_samples[i] = selected_samples[
                 i, self.transform_parameters["permutations"][i]
             ]
-        return selected_samples
+            if targets is not None:
+                targets[i] = targets[i, self.transform_parameters["permutations"][i]]
+
+        return selected_samples, targets

--- a/torch_audiomentations/augmentations/shuffle_channels.py
+++ b/torch_audiomentations/augmentations/shuffle_channels.py
@@ -1,9 +1,12 @@
-import typing
+from typing import Optional
 import warnings
 
 import torch
+from torch import Tensor
+
 
 from ..core.transforms_interface import BaseWaveformTransform
+from ..utils.object_dict import ObjectDict
 
 
 class ShuffleChannels(BaseWaveformTransform):
@@ -22,9 +25,9 @@ class ShuffleChannels(BaseWaveformTransform):
         self,
         mode: str = "per_example",
         p: float = 0.5,
-        p_mode: typing.Optional[str] = None,
-        sample_rate: typing.Optional[int] = None,
-        target_rate: typing.Optional[int] = None,
+        p_mode: Optional[str] = None,
+        sample_rate: Optional[int] = None,
+        target_rate: Optional[int] = None,
     ):
         super().__init__(
             mode=mode,
@@ -36,41 +39,49 @@ class ShuffleChannels(BaseWaveformTransform):
 
     def randomize_parameters(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
     ):
-        batch_size = selected_samples.shape[0]
-        num_channels = selected_samples.shape[1]
+        batch_size = samples.shape[0]
+        num_channels = samples.shape[1]
         assert num_channels <= 255
         permutations = torch.zeros(
-            (batch_size, num_channels), dtype=torch.int64, device=selected_samples.device
+            (batch_size, num_channels), dtype=torch.int64, device=samples.device
         )
         for i in range(batch_size):
-            permutations[i] = torch.randperm(num_channels, device=selected_samples.device)
+            permutations[i] = torch.randperm(num_channels, device=samples.device)
         self.transform_parameters["permutations"] = permutations
 
     def apply_transform(
         self,
-        selected_samples: torch.Tensor,
-        sample_rate: int = None,
-        targets: torch.Tensor = None,
-        target_rate: int = None,
-    ):
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
+    ) -> ObjectDict:
 
-        if selected_samples.shape[1] == 1:
+        if samples.shape[1] == 1:
             warnings.warn(
                 "Mono audio was passed to ShuffleChannels - there are no channels to shuffle."
                 " The input will be returned unchanged."
             )
-            return selected_samples, targets
+            return ObjectDict(
+                samples=samples,
+                sample_rate=sample_rate,
+                targets=targets,
+                target_rate=target_rate,
+            )
 
-        for i in range(selected_samples.size(0)):
-            selected_samples[i] = selected_samples[
-                i, self.transform_parameters["permutations"][i]
-            ]
+        for i in range(samples.size(0)):
+            samples[i] = samples[i, self.transform_parameters["permutations"][i]]
             if targets is not None:
                 targets[i] = targets[i, self.transform_parameters["permutations"][i]]
 
-        return selected_samples, targets
+        return ObjectDict(
+            samples=samples,
+            sample_rate=sample_rate,
+            targets=targets,
+            target_rate=target_rate,
+        )

--- a/torch_audiomentations/augmentations/time_inversion.py
+++ b/torch_audiomentations/augmentations/time_inversion.py
@@ -21,6 +21,7 @@ class TimeInversion(BaseWaveformTransform):
         p: float = 0.5,
         p_mode: str = None,
         sample_rate: int = None,
+        target_rate: int = None,
     ):
         """
         :param mode:
@@ -28,12 +29,32 @@ class TimeInversion(BaseWaveformTransform):
         :param p_mode:
         :param sample_rate:
         """
-        super().__init__(mode, p, p_mode, sample_rate)
+        super().__init__(
+            mode=mode,
+            p=p,
+            p_mode=p_mode,
+            sample_rate=sample_rate,
+            target_rate=target_rate,
+        )
 
-    def apply_transform(self, selected_samples: torch.Tensor, sample_rate: int = None):
+    def apply_transform(
+        self,
+        selected_samples: torch.Tensor,
+        sample_rate: int = None,
+        targets: torch.Tensor = None,
+        target_rate: int = None,
+    ):
+
         # torch.flip() is supposed to be slower than np.flip()
         # An alternative is to use advanced indexing: https://github.com/pytorch/pytorch/issues/16424
         # reverse_index = torch.arange(selected_samples.size(-1) - 1, -1, -1).to(selected_samples.device)
         # transformed_samples = selected_samples[..., reverse_index]
         # return transformed_samples
-        return torch.flip(selected_samples, dims=(-1,))
+
+        flipped_samples = torch.flip(selected_samples, dims=(-1,))
+        if targets is None:
+            flipped_targets = targets
+        else:
+            flipped_targets = torch.flip(targets, dims=(-2,))
+
+        return flipped_samples, flipped_targets

--- a/torch_audiomentations/core/composition.py
+++ b/torch_audiomentations/core/composition.py
@@ -86,7 +86,11 @@ class Compose(BaseCompose):
                 else:
                     # FIXME: add support for targets?
                     samples = self.transforms[i](samples)
-        return samples
+
+        if targets is None:
+            return samples
+        else:
+            return samples, targets
 
 
 class SomeOf(BaseCompose):
@@ -167,7 +171,11 @@ class SomeOf(BaseCompose):
                 else:
                     # FIXME: add support for targets?
                     samples = self.transforms[i](samples)
-        return samples
+
+        if targets is None:
+            return samples
+        else:
+            return samples, targets
 
 
 class OneOf(SomeOf):

--- a/torch_audiomentations/core/composition.py
+++ b/torch_audiomentations/core/composition.py
@@ -63,7 +63,13 @@ class BaseCompose(torch.nn.Module):
 
 
 class Compose(BaseCompose):
-    def forward(self, samples, sample_rate: typing.Optional[int] = None):
+    def forward(
+        self,
+        samples,
+        sample_rate: typing.Optional[int] = None,
+        targets=None,
+        target_rate: typing.Optional[int] = None,
+    ):
         if random.random() < self.p:
             transform_indexes = list(range(len(self.transforms)))
             if self.shuffle:
@@ -71,8 +77,14 @@ class Compose(BaseCompose):
             for i in transform_indexes:
                 tfm = self.transforms[i]
                 if isinstance(tfm, BaseWaveformTransform):
-                    samples = self.transforms[i](samples, sample_rate)
+                    if targets is None:
+                        samples = self.transforms[i](samples, sample_rate)
+                    else:
+                        samples, targets = self.transforms[i](
+                            samples, sample_rate, targets=targets, target_rate=target_rate
+                        )
                 else:
+                    # FIXME: add support for targets?
                     samples = self.transforms[i](samples)
         return samples
 
@@ -131,7 +143,13 @@ class SomeOf(BaseCompose):
             random.sample(self.all_transforms_indexes, num_transforms_to_apply)
         )
 
-    def forward(self, samples, sample_rate: typing.Optional[int] = None):
+    def forward(
+        self,
+        samples,
+        sample_rate: typing.Optional[int] = None,
+        targets=None,
+        target_rate: typing.Optional[int] = None,
+    ):
         if random.random() < self.p:
 
             if not self.are_parameters_frozen:
@@ -140,8 +158,14 @@ class SomeOf(BaseCompose):
             for i in self.transform_indexes:
                 tfm = self.transforms[i]
                 if isinstance(tfm, BaseWaveformTransform):
-                    samples = self.transforms[i](samples, sample_rate)
+                    if targets is None:
+                        samples = self.transforms[i](samples, sample_rate)
+                    else:
+                        samples, targets = self.transforms[i](
+                            samples, sample_rate, targets=targets, target_rate=target_rate
+                        )
                 else:
+                    # FIXME: add support for targets?
                     samples = self.transforms[i](samples)
         return samples
 

--- a/torch_audiomentations/core/transforms_interface.py
+++ b/torch_audiomentations/core/transforms_interface.py
@@ -112,7 +112,10 @@ class BaseWaveformTransform(torch.nn.Module):
             warnings.warn(
                 "An empty samples tensor was passed to {}".format(self.__class__.__name__)
             )
-            return samples
+            if targets is None:
+                return samples
+            else:
+                return samples, targets
 
         if len(samples.shape) != 3:
             raise RuntimeError(
@@ -445,7 +448,10 @@ class BaseWaveformTransform(torch.nn.Module):
             else:
                 raise Exception("Invalid p_mode {}".format(self.p_mode))
 
-        return samples
+        if targets is None:
+            return samples
+        else:
+            return samples, targets
 
     def _forward_unimplemented(self, *inputs) -> None:
         # Avoid IDE error message like "Class ... must implement all abstract methods"

--- a/torch_audiomentations/core/transforms_interface.py
+++ b/torch_audiomentations/core/transforms_interface.py
@@ -141,10 +141,10 @@ class BaseWaveformTransform(torch.nn.Module):
         if sample_rate is None and self.is_sample_rate_required():
             raise RuntimeError("sample_rate is required")
 
-        if self.is_targets_required():
+        if targets is None and self.is_targets_required():
+            raise RuntimeError("targets is required")
 
-            if targets is None:
-                raise RuntimeError("targets is required")
+        if targets is not None:
 
             if len(targets.shape) != 4:
                 raise RuntimeError(

--- a/torch_audiomentations/utils/io.py
+++ b/torch_audiomentations/utils/io.py
@@ -84,16 +84,16 @@ class Audio:
 
         Parameters
         ----------
-        samples : (channel, time) Tensor
-            Single or multichannel samples
+        samples : (..., time) Tensor
+            Single (or multichannel) samples or batch of samples
 
         Returns
         -------
-        samples: (channel, time) Tensor
+        samples: (..., time) Tensor
             Power-normalized samples
         """
-        rms = samples.square().mean(dim=1).sqrt()
-        return (samples.t() / (rms + 1e-8)).t()
+        rms = samples.square().mean(dim=-1, keepdim=True).sqrt()
+        return samples / (rms + 1e-8)
 
     @staticmethod
     def get_audio_metadata(file_path) -> tuple:

--- a/torch_audiomentations/utils/object_dict.py
+++ b/torch_audiomentations/utils/object_dict.py
@@ -1,0 +1,39 @@
+# Inspired by tornado
+# https://www.tornadoweb.org/en/stable/_modules/tornado/util.html#ObjectDict
+
+try:
+    import typing
+    from typing import cast
+
+    _ObjectDictBase = typing.Dict[str, typing.Any]
+except ImportError:
+    _ObjectDictBase = dict
+
+
+class ObjectDict(_ObjectDictBase):
+    """
+    Make a dictionary behave like an object, with attribute-style access.
+
+    Here are some examples of how it can be used:
+    
+    o = ObjectDict(my_dict)
+    # or like this:
+    o = ObjectDict(samples=samples, sample_rate=sample_rate)
+
+    # Attribute-style access
+    samples = o.samples
+
+    # Dict-style access
+    samples = o["samples"]
+    """
+
+    def __getattr__(self, name):
+        # type: (str) -> Any
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        # type: (str, Any) -> None
+        self[name] = value

--- a/torch_audiomentations/utils/object_dict.py
+++ b/torch_audiomentations/utils/object_dict.py
@@ -1,13 +1,9 @@
 # Inspired by tornado
 # https://www.tornadoweb.org/en/stable/_modules/tornado/util.html#ObjectDict
 
-try:
-    import typing
-    from typing import cast
+import typing
 
-    _ObjectDictBase = typing.Dict[str, typing.Any]
-except ImportError:
-    _ObjectDictBase = dict
+_ObjectDictBase = typing.Dict[str, typing.Any]
 
 
 class ObjectDict(_ObjectDictBase):


### PR DESCRIPTION
This is an initial attempt at addressing #3.
The proposed API assumes the following shapes:
* samples: `(batch_size, num_channels, num_samples)`
* targets: `(batch_size, num_channels, num_frames, num_classes)`

| Input | Target | `num_frames` | `num_classes`|
| --- | --- | --- | --- |
| Audio | class(es), fixed length, not correlated with the input length. Low priority. | 1 | 1 or more |
| Audio | Time series of class(es).  | more than 1 | 1 or more
| Audio | Audio (length same as the input). | `num_samples` | 1

and is used like that

```python
augment = MixSamples()
augmented = augment(samples, targets=targets)
mixed_samples = augmented.samples
mixed_targets = augmented.targets
```
