### PR TITLE
Support passing list of folders to ApplyImpulseResponse/AddBackgroundNoise

### DIFF
--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from tests.utils import TEST_FIXTURES_DIR
-from torch_audiomentations.utils.file import find_audio_files
+from torch_audiomentations.utils.file import find_audio_files, find_audio_files_in_paths
 
 
 class TestFileUtils:
@@ -17,6 +17,21 @@ class TestFileUtils:
         file_paths = [Path(fp).name for fp in file_paths]
         assert set(file_paths) == {
             "acoustic_guitar_0.wav",
+            "bg.wav",
+            "bg_short.WAV",
+            "impulse_response_0.wav",
+            "stereo_noise.wav",
+        }
+
+    def test_find_audio_files_in_paths(self):
+        paths = [
+            os.path.join(TEST_FIXTURES_DIR, "bg"),
+            os.path.join(TEST_FIXTURES_DIR, "bg_short"),
+            os.path.join(TEST_FIXTURES_DIR, "ir", "impulse_response_0.wav"),
+        ]
+        file_paths = find_audio_files_in_paths(paths)
+        file_paths = [Path(fp).name for fp in file_paths]
+        assert set(file_paths) == {
             "bg.wav",
             "bg_short.WAV",
             "impulse_response_0.wav",

--- a/torch_audiomentations/augmentations/background_noise.py
+++ b/torch_audiomentations/augmentations/background_noise.py
@@ -6,7 +6,7 @@ import torch
 
 from ..core.transforms_interface import BaseWaveformTransform, EmptyPathException
 from ..utils.dsp import calculate_rms
-from ..utils.file import find_audio_files
+from ..utils.file import find_audio_files_in_paths, SUPPORTED_EXTENSIONS
 from ..utils.io import Audio
 
 
@@ -44,11 +44,8 @@ class AddBackgroundNoise(BaseWaveformTransform):
 
         super().__init__(mode, p, p_mode, sample_rate)
 
-        if isinstance(background_paths, (list, tuple, set)):
-            # TODO: check that one can read audio files
-            self.background_paths = list(background_paths)
-        else:
-            self.background_paths = find_audio_files(background_paths)
+        # TODO: check that one can read audio files
+        self.background_paths = find_audio_files_in_paths(background_paths)        
 
         if sample_rate is not None:
             self.audio = Audio(sample_rate=sample_rate, mono=True)

--- a/torch_audiomentations/augmentations/impulse_response.py
+++ b/torch_audiomentations/augmentations/impulse_response.py
@@ -7,7 +7,7 @@ from torch.nn.utils.rnn import pad_sequence
 
 from ..core.transforms_interface import BaseWaveformTransform, EmptyPathException
 from ..utils.convolution import convolve
-from ..utils.file import find_audio_files
+from ..utils.file import find_audio_files_in_paths
 from ..utils.io import Audio
 
 
@@ -46,11 +46,8 @@ class ApplyImpulseResponse(BaseWaveformTransform):
         """
         super().__init__(mode, p, p_mode, sample_rate)
 
-        if isinstance(ir_paths, (list, tuple, set)):
-            # TODO: check that one can read audio files
-            self.ir_paths = list(ir_paths)
-        else:
-            self.ir_paths = find_audio_files(ir_paths)
+        # TODO: check that one can read audio files
+        self.ir_paths = find_audio_files_in_paths(ir_paths)
 
         if sample_rate is not None:
             self.audio = Audio(sample_rate=sample_rate, mono=True)

--- a/torch_audiomentations/utils/file.py
+++ b/torch_audiomentations/utils/file.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import List, Union
 
 import soundfile
 
@@ -7,6 +8,36 @@ from .dsp import resample_audio
 
 SUPPORTED_EXTENSIONS = (".wav",)
 
+def find_audio_files_in_paths(
+    paths: Union[List[Path], List[str], Path, str],
+    filename_endings=SUPPORTED_EXTENSIONS,
+    traverse_subdirectories=True,
+    follow_symlinks=True,
+):
+    """Return a list of paths to all audio files with the given extension(s) contained in the list or in its directories.
+    Also traverses subdirectories by default.
+    """
+
+    file_paths = []
+
+
+    if isinstance(paths, (list, tuple, set)):
+        paths = list(paths)
+    else:
+        paths = [paths]
+
+    for p in paths:
+        if str(p).lower().endswith(SUPPORTED_EXTENSIONS):
+            file_path = Path(os.path.abspath(p))
+            file_paths.append(file_path)
+        elif os.path.isdir(p):
+            file_paths += find_audio_files(
+                p,
+                filename_endings=filename_endings,
+                traverse_subdirectories=traverse_subdirectories,
+                follow_symlinks=follow_symlinks
+            )
+    return file_paths
 
 def find_audio_files(
     root_path,


### PR DESCRIPTION
ApplyImpulseResponse/AddBackgroundNoise allow as parameter for their audio files either a single folder path, or a list of individual file paths.

This PR adds the `find_audio_files_in_paths` function that is now used instead of `find_audio_files` in `ApplyImpulseResponse`/`AddBackgroundNoise` and which allows either a single file path, a single folder path, or a list of file/folder paths.

This aims to address the issue #122 .