### PR TITLE
feat: add support for batches in Audio.rms_normalize

### DIFF
--- a/torch_audiomentations/utils/io.py
+++ b/torch_audiomentations/utils/io.py
@@ -84,16 +84,16 @@ class Audio:
 
         Parameters
         ----------
-        samples : (channel, time) Tensor
-            Single or multichannel samples
+        samples : (..., time) Tensor
+            Single (or multichannel) samples or batch of samples
 
         Returns
         -------
-        samples: (channel, time) Tensor
+        samples: (..., time) Tensor
             Power-normalized samples
         """
-        rms = samples.square().mean(dim=1).sqrt()
-        return (samples.t() / (rms + 1e-8)).t()
+        rms = samples.square().mean(dim=-1, keepdim=True).sqrt()
+        return samples / (rms + 1e-8)
 
     @staticmethod
     def get_audio_metadata(file_path) -> tuple:


### PR DESCRIPTION
Audio.rms_normalize currently only works for (channel, time)-shaped samples. 

This PR adds support for (batch_size, channel, time)-shaped samples as well, which is the usual shape of `selected_samples` in `randomize_parameters` and `apply_transform`.