### PR TITLE
torch-pitch-shift>=1.2.2

### DIFF
--- a/.github/workflows/test_requirements.txt
+++ b/.github/workflows/test_requirements.txt
@@ -10,4 +10,4 @@ pytest==5.3.4
 pytest-cov==2.8.1
 coverage==4.5.2
 PyYAML>=5.3.1
-torch-pitch-shift>=1.2.0
+torch-pitch-shift>=1.2.1

--- a/.github/workflows/test_requirements.txt
+++ b/.github/workflows/test_requirements.txt
@@ -10,4 +10,4 @@ pytest==5.3.4
 pytest-cov==2.8.1
 coverage==4.5.2
 PyYAML>=5.3.1
-torch-pitch-shift>=1.2.1
+torch-pitch-shift>=1.2.2

--- a/environment.yml
+++ b/environment.yml
@@ -28,4 +28,4 @@ dependencies:
   - setuptools>=41.0.0
   - tqdm==4.49.0
   - twine
-  - torch-pitch-shift>=1.2.1
+  - torch-pitch-shift>=1.2.2

--- a/environment.yml
+++ b/environment.yml
@@ -28,4 +28,4 @@ dependencies:
   - setuptools>=41.0.0
   - tqdm==4.49.0
   - twine
-  - torch-pitch-shift>=1.2.0
+  - torch-pitch-shift>=1.2.1

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "librosa>=0.6.0",
         "torch>=1.7.0",
         "torchaudio>=0.7.0",
-        "torch-pitch-shift>=1.2.0",
+        "torch-pitch-shift>=1.2.1",
     ],
     extras_require={"extras": ["PyYAML"]},
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "librosa>=0.6.0",
         "torch>=1.7.0",
         "torchaudio>=0.7.0",
-        "torch-pitch-shift>=1.2.1",
+        "torch-pitch-shift>=1.2.2",
     ],
     extras_require={"extras": ["PyYAML"]},
     python_requires=">=3.6",


### PR DESCRIPTION
`torchaudio` 0.11 migrated all functions and transforms to PyTorch native complex Tensor type, which causes `pitch_shift` to break. This adds support for `torchaudio` v0.11.