### PR TITLE
feat: add Identity transform

### DIFF
--- a/torch_audiomentations/__init__.py
+++ b/torch_audiomentations/__init__.py
@@ -4,6 +4,7 @@ from .augmentations.band_stop_filter import BandStopFilter
 from .augmentations.colored_noise import AddColoredNoise
 from .augmentations.gain import Gain
 from .augmentations.high_pass_filter import HighPassFilter
+from .augmentations.identity import Identity
 from .augmentations.impulse_response import ApplyImpulseResponse
 from .augmentations.low_pass_filter import LowPassFilter
 from .augmentations.mix import Mix

--- a/torch_audiomentations/augmentations/identity.py
+++ b/torch_audiomentations/augmentations/identity.py
@@ -1,0 +1,30 @@
+from typing import Optional
+from torch import Tensor
+
+from ..core.transforms_interface import BaseWaveformTransform
+from ..utils.object_dict import ObjectDict
+
+
+class Identity(BaseWaveformTransform):
+
+    supported_modes = {"per_batch", "per_example", "per_channel"}
+    supports_multichannel = True
+    requires_sample_rate = False
+    supports_target = True
+    requires_target = False
+
+    def apply_transform(
+        self,
+        samples: Tensor = None,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
+    ) -> ObjectDict:
+
+        return ObjectDict(
+            samples=samples,
+            sample_rate=sample_rate,
+            targets=targets,
+            target_rate=target_rate,
+        )
+


### PR DESCRIPTION
This PR adds the `Identity` transform that basically does nothing (i.e. returns its input unchanged).

One benefit is to simplify codebase of other libraries  using `torch_audiomentations` (pyannote.audio, I am looking at you ;)):

Before:

```python
if use_augmentation:
    augmentation = MyAugmentation(...)

for samples in dataloader:

  if use_augmentation:
     augmented = augmentation(samples, ...)
  else:
     augmented = samples
```

After: 

```python
augmentation = MyAugmentation(...) if use_augmentation else Identity()

for samples in dataloader:
   augmented = augmentation(samples, ...)
```

