### PR TITLE
add SpliceOut to torch_audiomentations init

### DIFF
--- a/torch_audiomentations/__init__.py
+++ b/torch_audiomentations/__init__.py
@@ -15,6 +15,7 @@ from .augmentations.polarity_inversion import PolarityInversion
 from .augmentations.shift import Shift
 from .augmentations.shuffle_channels import ShuffleChannels
 from .augmentations.time_inversion import TimeInversion
+from .augmentations.spliceout import SpliceOut
 from .core.composition import Compose, SomeOf, OneOf
 from .utils.config import from_dict, from_yaml
 from .utils.convolution import convolve


### PR DESCRIPTION
Since SpliceOut is not in the main `__init__.py` fiie, it can not be used when loading a configuration using e.g. `from_yaml`. Fixes #144 