### PR TITLE
Removing set_backend to avoid torchaudio UserWarning

### DIFF
--- a/torch_audiomentations/utils/io.py
+++ b/torch_audiomentations/utils/io.py
@@ -23,8 +23,8 @@ The optional "channel" key can be used to indicate a specific channel.
 """
 
 # TODO: Remove this when it is the default
-torchaudio.USE_SOUNDFILE_LEGACY_INTERFACE = False
-torchaudio.set_audio_backend("soundfile")
+# torchaudio.USE_SOUNDFILE_LEGACY_INTERFACE = False
+# torchaudio.set_audio_backend("soundfile")
 
 
 class Audio:

--- a/torch_audiomentations/utils/io.py
+++ b/torch_audiomentations/utils/io.py
@@ -22,10 +22,6 @@ Audio files can be provided to the Audio class using different types:
 The optional "channel" key can be used to indicate a specific channel.
 """
 
-# TODO: Remove this when it is the default
-# torchaudio.USE_SOUNDFILE_LEGACY_INTERFACE = False
-# torchaudio.set_audio_backend("soundfile")
-
 
 class Audio:
     """Audio IO with on-the-fly resampling


### PR DESCRIPTION
Commented out the `set_backend` to avoid `torchaudio` UserWarning.

Ref. #172