### PR TITLE
Bugfix: AddColoredNoise edge-case shape error

### DIFF
--- a/tests/test_colored_noise.py
+++ b/tests/test_colored_noise.py
@@ -69,6 +69,15 @@ class TestAddColoredNoise(unittest.TestCase):
         self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
         self.assertEqual(mixed_input.size(1), self.input_audio.size(1))
 
+    def test_colored_noise_guaranteed_with_single_tensor_edgecase_sample_rate(self):
+        signal = torch.zeros(1, 1, 16001)
+        mixed_input = self.cl_noise_transform_guaranteed(
+            signal, 16001
+        ).samples
+        self.assertFalse(torch.equal(mixed_input, self.input_audio))
+        self.assertEqual(mixed_input.size(0), self.input_audio.size(0))
+        self.assertEqual(mixed_input.size(1), self.input_audio.size(1))
+
     def test_colored_noise_guaranteed_with_batched_tensor(self):
         random.seed(42)
         mixed_inputs = self.cl_noise_transform_guaranteed(

--- a/torch_audiomentations/augmentations/colored_noise.py
+++ b/torch_audiomentations/augmentations/colored_noise.py
@@ -27,7 +27,7 @@ def _gen_noise(f_decay, num_samples, sample_rate, device):
     )
     spec *= mask
     noise = Audio.rms_normalize(irfft(spec).unsqueeze(0)).squeeze()
-    noise = torch.cat([noise] * int(ceil(num_samples / sample_rate)))
+    noise = torch.cat([noise] * int(ceil(num_samples / noise.shape[0])))
     return noise[:num_samples]
 
 


### PR DESCRIPTION
# Description
AddColoredNoise errors on certain signal lengths and sample rates.

# Reproduce
```
import torch
from torch_audiomentations.augmentations.colored_noise import AddColoredNoise
transform = AddColoredNoise(p=1)
transform(torch.zeros(1, 1, 33075), sample_rate=33075)
```
raises the error
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1510, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1519, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch_audiomentations/core/transforms_interface.py", line 341, in forward
    perturbed: ObjectDict = self.apply_transform(
  File "/usr/local/lib/python3.10/dist-packages/torch_audiomentations/augmentations/colored_noise.py", line 159, in apply_transform
    * noise.view(batch_size, 1, num_samples).expand(-1, num_channels, -1),
RuntimeError: shape '[1, 1, 33075]' is invalid for input of size 33074
```

# Cause
- in `_gen_noise` there is an [rfft -> scale -> irfft operation](https://github.com/asteroid-team/torch-audiomentations/blob/ee32374ec26acb99478c235d85ed46cf7600845b/torch_audiomentations/augmentations/colored_noise.py#L23)
- For odd sample rates the generated noise is one sample shorter than the sample rate.
- This can cause the [noise repitition](https://github.com/asteroid-team/torch-audiomentations/blob/ee32374ec26acb99478c235d85ed46cf7600845b/torch_audiomentations/augmentations/colored_noise.py#L30) in _gen_noise to end up too short, causing a shape mismatch

# Fix
modify the [noise repetition](https://github.com/asteroid-team/torch-audiomentations/blob/ee32374ec26acb99478c235d85ed46cf7600845b/torch_audiomentations/augmentations/colored_noise.py#L30) to
```
noise = torch.cat([noise] * int(ceil(num_samples / noise.shape[0])))
```
implemented in this PR