### PR TITLE
Add RMSNormalization transform for target-level RMS normalisation (closes #176)

### DIFF
--- a/tests/test_rms_normalization.py
+++ b/tests/test_rms_normalization.py
@@ -1,0 +1,58 @@
+import unittest
+import torch
+
+from torch_audiomentations import RMSNormalization
+
+# Allow some tolerance in dB comparisons due to numeric imprecision
+THRESHOLD_DB = 1.0
+
+class TestRMSNormalization(unittest.TestCase):
+    def test_sine_wave_adjustment(self):
+        """Transform should adjust a 440 Hz sine from -20 dBFS to -10 dBFS"""
+        sample_rate = 16000
+        t = torch.arange(0, sample_rate) / sample_rate
+        wave = torch.sin(2 * torch.pi * 440 * t)
+
+        # Scale to -20 dBFS
+        current_rms = torch.sqrt(torch.mean(wave.pow(2)))
+        target_amp = 10 ** (-20.0 / 20.0)
+        wave = wave * (target_amp / current_rms)
+
+        transform = RMSNormalization(-10.0)
+        result = transform(wave.unsqueeze(0).unsqueeze(0), sample_rate)
+
+        # Compute RMS of output
+        out_rms = torch.sqrt(torch.mean(result.samples.pow(2))).item()
+
+        # Manual RMS calculation for cross-check
+        flattened = result.samples.flatten()
+        total_power = sum(float(v) ** 2 for v in flattened)
+        rms_manual = (total_power / flattened.numel()) ** 0.5
+
+        # Convert to dB
+        out_db = 20 * torch.log10(torch.tensor(out_rms)).item()
+
+        # Verify vectorised and manual agree and that output is within tolerance
+        assert abs(out_rms - rms_manual) < 1e-6
+        assert abs(out_db + 10.0) < THRESHOLD_DB
+
+    def test_silence_stays_zero(self):
+        """Transform should leave a silent input unchanged"""
+        zeros = torch.zeros(1, 1, 8000)
+        result = RMSNormalization(-5.0)(zeros, 16000)
+        self.assertTrue(torch.all(result.samples == 0))
+
+    def test_stereo_equal_gain(self):
+        """Left and right channels should be scaled by the same gain"""
+        left  = torch.full((1, 1, 1000), 0.1)
+        right = torch.full((1, 1, 1000), 0.2)
+        stereo = torch.cat([left, right], dim = 1)
+
+        transform = RMSNormalization(-6.0)
+        result = transform(stereo, 16000)
+
+        gain_left  = result.samples[0, 0, 0] / 0.1
+        gain_right = result.samples[0, 1, 0] / 0.2
+
+        # Allow small relative difference
+        self.assertAlmostEqual(gain_left, gain_right, places = 3)

--- a/torch_audiomentations/__init__.py
+++ b/torch_audiomentations/__init__.py
@@ -10,6 +10,7 @@ from .augmentations.low_pass_filter import LowPassFilter
 from .augmentations.peak_normalization import PeakNormalization
 from .augmentations.pitch_shift import PitchShift
 from .augmentations.polarity_inversion import PolarityInversion
+from .augmentations.rms_normalization import RMSNormalization
 from .augmentations.shift import Shift
 from .augmentations.shuffle_channels import ShuffleChannels
 from .augmentations.time_inversion import TimeInversion

--- a/torch_audiomentations/augmentations/rms_normalization.py
+++ b/torch_audiomentations/augmentations/rms_normalization.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 from ..core.transforms_interface import BaseWaveformTransform
 from ..utils.object_dict import ObjectDict
-from ..utils import db_to_amplitude
 
 class RMSNormalization(BaseWaveformTransform):
     
@@ -22,17 +21,19 @@ class RMSNormalization(BaseWaveformTransform):
         target_level_dbfs: float,
         eps: float = 1e-9,
         mode: str = "per_example",
-        p: float = 0.5,
+        p: float = 1.0,
         p_mode: Optional[str] = None,
+        output_type: Optional[str] = "dict",
     ):
         super().__init__(
             mode = mode,
             p = p,
             p_mode = p_mode,
+            output_type=output_type
         )
         
         # Convert target dBFS to linear amplitude
-        self.target_amp = db_to_amplitude(target_level_dbfs)
+        self.target_amp = 10 ** (target_level_dbfs / 20.0)
         self.eps = eps
 
     def apply_transform(

--- a/torch_audiomentations/augmentations/rms_normalization.py
+++ b/torch_audiomentations/augmentations/rms_normalization.py
@@ -24,28 +24,11 @@ class RMSNormalization(BaseWaveformTransform):
         mode: str = "per_example",
         p: float = 0.5,
         p_mode: Optional[str] = None,
-        sample_rate: Optional[int] = None,
-        target_rate: Optional[int] = None,
-        output_type: Optional[str] = None,
     ):
-        """
-        Args:
-          target_level_dbfs (float): Desired RMS in dBFS.
-          eps (float): Small constant for numeric stability.
-          mode (str): “per_example”, “per_channel” or “per_batch”.
-          p (float): Probability of applying the transform (default 0.5).
-          p_mode (Optional[str]): Secondary probability mode.
-          sample_rate (Optional[int]): Sample rate, if required.
-          target_rate (Optional[int]): Target sample rate.
-          output_type (Optional[str]): “tensor” or “dict” output.
-        """
         super().__init__(
             mode = mode,
             p = p,
             p_mode = p_mode,
-            sample_rate = sample_rate,
-            target_rate = target_rate,
-            output_type = output_type,
         )
         
         # Convert target dBFS to linear amplitude

--- a/torch_audiomentations/augmentations/rms_normalization.py
+++ b/torch_audiomentations/augmentations/rms_normalization.py
@@ -1,0 +1,55 @@
+import torch
+from torch import Tensor
+from typing import Optional
+
+from ..core.transforms_interface import BaseWaveformTransform
+from ..utils.object_dict import ObjectDict
+
+class RMSNormalization(BaseWaveformTransform):
+    
+    """
+    Adjusts gain so signal’s overall RMS matches `target_level_dbfs`
+
+    Args:
+      target_level_dbfs (float): desired RMS in dBFS.
+      eps (float): small constant for numeric stability (default 1e-9)
+    """
+    
+    supports_multichannel = True
+    requires_sample_rate = False
+    supports_target = False
+    requires_target = False
+
+    def __init__(self,
+                 target_level_dbfs: float,
+                 eps: float = 1e-9,
+                 p: float = 1.0,
+                 output_type: str = "dict"):
+        # p = probability, output_type chooses dict vs tensor
+        super().__init__(p = p, output_type = output_type)
+        # Convert dBFS to linear gain
+        self.target_amp = 10 ** (target_level_dbfs / 20.0)
+        self.eps = eps
+
+    def apply_transform(
+        self,
+        samples: Tensor,
+        sample_rate: Optional[int] = None,
+        targets: Optional[Tensor] = None,
+        target_rate: Optional[int] = None,
+    ) -> ObjectDict:
+        
+        # Compute combined rms
+        rms = samples.pow(2).mean(dim = (-1, -2), keepdim = True).sqrt()
+        
+        # Derive gain
+        gain = self.target_amp / (rms + self.eps)
+        
+        # Apply gain
+        out = samples * gain
+        return ObjectDict(
+            samples = out,
+            sample_rate = sample_rate,
+            targets = targets,
+            target_rate = target_rate,
+        )

--- a/torch_audiomentations/augmentations/rms_normalization.py
+++ b/torch_audiomentations/augmentations/rms_normalization.py
@@ -4,15 +4,12 @@ from typing import Optional
 
 from ..core.transforms_interface import BaseWaveformTransform
 from ..utils.object_dict import ObjectDict
+from ..utils import db_to_amplitude
 
 class RMSNormalization(BaseWaveformTransform):
     
     """
     Adjusts gain so signal’s overall RMS matches `target_level_dbfs`
-
-    Args:
-      target_level_dbfs (float): desired RMS in dBFS.
-      eps (float): small constant for numeric stability (default 1e-9)
     """
     
     supports_multichannel = True
@@ -20,15 +17,39 @@ class RMSNormalization(BaseWaveformTransform):
     supports_target = False
     requires_target = False
 
-    def __init__(self,
-                 target_level_dbfs: float,
-                 eps: float = 1e-9,
-                 p: float = 1.0,
-                 output_type: str = "dict"):
-        # p = probability, output_type chooses dict vs tensor
-        super().__init__(p = p, output_type = output_type)
-        # Convert dBFS to linear gain
-        self.target_amp = 10 ** (target_level_dbfs / 20.0)
+    def __init__(
+        self,
+        target_level_dbfs: float,
+        eps: float = 1e-9,
+        mode: str = "per_example",
+        p: float = 0.5,
+        p_mode: Optional[str] = None,
+        sample_rate: Optional[int] = None,
+        target_rate: Optional[int] = None,
+        output_type: Optional[str] = None,
+    ):
+        """
+        Args:
+          target_level_dbfs (float): Desired RMS in dBFS.
+          eps (float): Small constant for numeric stability.
+          mode (str): “per_example”, “per_channel” or “per_batch”.
+          p (float): Probability of applying the transform (default 0.5).
+          p_mode (Optional[str]): Secondary probability mode.
+          sample_rate (Optional[int]): Sample rate, if required.
+          target_rate (Optional[int]): Target sample rate.
+          output_type (Optional[str]): “tensor” or “dict” output.
+        """
+        super().__init__(
+            mode = mode,
+            p = p,
+            p_mode = p_mode,
+            sample_rate = sample_rate,
+            target_rate = target_rate,
+            output_type = output_type,
+        )
+        
+        # Convert target dBFS to linear amplitude
+        self.target_amp = db_to_amplitude(target_level_dbfs)
         self.eps = eps
 
     def apply_transform(


### PR DESCRIPTION
### Summary
Adds a new `RMSNormalization` transform (subclass of `BaseWaveformTransform`) that:

- Converts a target RMS level in dBFS into a linear gain factor
- Computes the combined‐signal RMS, applies gain = target_amp / (rms + eps)
- Returns results in an `ObjectDict` (samples, sample_rate, etc.)

### Tests
Includes three basic tests covering:
1. Adjusting a 440 Hz sine wave from -20 dBFS to -10 dBFS
2. Leaving silent input unchanged
3. Applying equal gain to both channels of a stereo signal

### Issue
Closes issue #176

---
Let me know if you’d like any further tweaks, thanks!